### PR TITLE
Add Brotli to NGINX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,69 @@
-# pull the Node.js Docker image
-FROM nginx:mainline
+ARG NGINX_VERSION="1.23.1"
+ARG NGINX_NAME="nginx-${NGINX_VERSION}"
 
-# DEPENDENCIES
+FROM debian as build
+
+ARG NGINX_VERSION
+ARG NGINX_NAME
+ARG CONFIG=" --prefix=/etc/nginx \
+ --sbin-path=/usr/sbin/nginx \
+ --modules-path=/usr/lib/nginx/modules \
+ --conf-path=/etc/nginx/nginx.conf \
+ --http-log-path=/var/log/nginx/node-access.log \
+ --pid-path=/var/run/nginx.pid \
+ --lock-path=/var/run/nginx.lock \
+ --user=nginx --group=nginx \
+ --with-compat \
+ --with-file-aio \
+ --with-threads \
+ --with-http_addition_module \
+ --with-http_auth_request_module \
+ --with-http_dav_module \
+ --with-http_flv_module \
+ --with-http_gunzip_module \
+ --with-http_gzip_static_module \
+ --with-http_mp4_module \
+ --with-http_random_index_module \
+ --with-http_realip_module \
+ --with-http_secure_link_module \
+ --with-http_slice_module \
+ --with-http_ssl_module \
+ --with-http_stub_status_module \
+ --with-http_sub_module \
+ --with-http_v2_module \
+ --with-mail \
+ --with-mail_ssl_module \
+ --with-stream \
+ --with-stream_realip_module \
+ --with-stream_ssl_module \
+ --with-stream_ssl_preread_module \
+ --with-compat \
+ --add-dynamic-module=/usr/src/ngx_brotli"
+
+# Install dependencies
+RUN apt-get update && apt-get install \
+    dpkg-dev build-essential gnupg2 \
+    git gcc cmake libpcre3 libpcre3-dev \
+    zlib1g zlib1g-dev openssl libssl-dev \
+    curl unzip wget libxslt-dev -y
+
+WORKDIR /usr/src
+
+# Install nginx + brotli module from source
+RUN wget http://nginx.org/download/${NGINX_NAME}.tar.gz \
+    && tar -xzvf ${NGINX_NAME}.tar.gz \
+    && git clone https://github.com/google/ngx_brotli.git --recursive \
+    && cd ${NGINX_NAME} \
+    && ./configure $CONFIG \
+    && make
+
+FROM nginx:${NGINX_VERSION}
+
+ARG NGINX_NAME
+
+COPY --from=build /usr/src/${NGINX_NAME}/objs/ngx_http_brotli_filter_module.so /usr/lib/nginx/modules/
+COPY --from=build /usr/src/${NGINX_NAME}/objs/ngx_http_brotli_static_module.so /usr/lib/nginx/modules/
+
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 # RUN curl -fsSL https://install.speedtest.net/app/cli/install.deb.sh | bash -
 RUN curl -fsSL https://packagecloud.io/install/repositories/ookla/speedtest-cli/script.deb.sh | bash -

--- a/container/nginx/nginx.conf
+++ b/container/nginx/nginx.conf
@@ -39,8 +39,19 @@ http {
     open_file_cache_valid    60m;
     open_file_cache_min_uses 1;
 
+    gzip on;
+    gzip_types text/html text/richtext text/plain text/css text/x-script text/x-component
+               text/x-java-source text/x-markdown application/javascript application/x-javascript
+               text/javascript text/js image/x-icon image/vnd.microsoft.icon application/x-perl
+               application/x-httpd-cgi text/xml application/xml application/xml+rss application/vnd.api+json
+               application/x-protobuf application/json multipart/bag multipart/mixed application/xhtml+xml
+               font/ttf font/otf font/x-woff image/svg+xml application/vnd.ms-fontobject application/ttf
+               application/x-ttf application/otf application/x-otf application/truetype application/opentype
+               application/x-opentype application/font-woff application/eot application/font application/font-sfnt
+               application/wasm application/javascript-binast application/manifest+json application/ld+json
+               application/graphql+json application/geo+json;
     brotli on;
-    brotli_types text/html text/richtext text/plain text/css text/x-script text/x-component
+    brotli_types text/richtext text/plain text/css text/x-script text/x-component
                  text/x-java-source text/x-markdown application/javascript application/x-javascript
                  text/javascript text/js image/x-icon image/vnd.microsoft.icon application/x-perl
                  application/x-httpd-cgi text/xml application/xml application/xml+rss application/vnd.api+json

--- a/container/nginx/nginx.conf
+++ b/container/nginx/nginx.conf
@@ -1,3 +1,6 @@
+load_module /usr/lib/nginx/modules/ngx_http_brotli_filter_module.so;
+load_module /usr/lib/nginx/modules/ngx_http_brotli_static_module.so;
+
 user  nginx;
 worker_processes  auto;
 
@@ -11,6 +14,17 @@ events {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
+    brotli on;
+    brotli_types text/html text/richtext text/plain text/css text/x-script text/x-component
+                 text/x-java-source text/x-markdown application/javascript application/x-javascript
+                 text/javascript text/js image/x-icon image/vnd.microsoft.icon application/x-perl
+                 application/x-httpd-cgi text/xml application/xml application/xml+rss application/vnd.api+json
+                 application/x-protobuf application/json multipart/bag multipart/mixed application/xhtml+xml
+                 font/ttf font/otf font/x-woff image/svg+xml application/vnd.ms-fontobject application/ttf
+                 application/x-ttf application/otf application/x-otf application/truetype application/opentype
+                 application/x-opentype application/font-woff application/eot application/font application/font-sfnt
+                 application/wasm application/javascript-binast application/manifest+json application/ld+json
+                 application/graphql+json application/geo+json;
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/container/nginx/nginx.conf
+++ b/container/nginx/nginx.conf
@@ -14,17 +14,6 @@ events {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
-    brotli on;
-    brotli_types text/html text/richtext text/plain text/css text/x-script text/x-component
-                 text/x-java-source text/x-markdown application/javascript application/x-javascript
-                 text/javascript text/js image/x-icon image/vnd.microsoft.icon application/x-perl
-                 application/x-httpd-cgi text/xml application/xml application/xml+rss application/vnd.api+json
-                 application/x-protobuf application/json multipart/bag multipart/mixed application/xhtml+xml
-                 font/ttf font/otf font/x-woff image/svg+xml application/vnd.ms-fontobject application/ttf
-                 application/x-ttf application/otf application/x-otf application/truetype application/opentype
-                 application/x-opentype application/font-woff application/eot application/font application/font-sfnt
-                 application/wasm application/javascript-binast application/manifest+json application/ld+json
-                 application/graphql+json application/geo+json;
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
@@ -49,6 +38,18 @@ http {
     open_file_cache          max=10000 inactive=60m;
     open_file_cache_valid    60m;
     open_file_cache_min_uses 1;
+
+    brotli on;
+    brotli_types text/html text/richtext text/plain text/css text/x-script text/x-component
+                 text/x-java-source text/x-markdown application/javascript application/x-javascript
+                 text/javascript text/js image/x-icon image/vnd.microsoft.icon application/x-perl
+                 application/x-httpd-cgi text/xml application/xml application/xml+rss application/vnd.api+json
+                 application/x-protobuf application/json multipart/bag multipart/mixed application/xhtml+xml
+                 font/ttf font/otf font/x-woff image/svg+xml application/vnd.ms-fontobject application/ttf
+                 application/x-ttf application/otf application/x-otf application/truetype application/opentype
+                 application/x-opentype application/font-woff application/eot application/font application/font-sfnt
+                 application/wasm application/javascript-binast application/manifest+json application/ld+json
+                 application/graphql+json application/geo+json;
     # == end custom node directives ==
 
     include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
Fixes #21.

This PR contains:
- A new Dockerfile that uses a multi-stage build to:
(Stage 1) Compile from source Nginx, get the Brotli and generate the `.so` files for the modules.
(Stage 2) By using the official `nginx` Docker image, the modules are moved to the corresponding directory.
- Changes in the `nginx.conf` file to enable Brotli, along with the supported types.

NOTE: `text/html` is always compressed, but I have added it to the supported types, just in case this default behavior changes in the future.
