### PR TITLE
Retrieve mime type for CAR files

### DIFF
--- a/container/nginx/nginx.conf
+++ b/container/nginx/nginx.conf
@@ -66,7 +66,8 @@ http {
                  application/x-ttf application/otf application/x-otf application/truetype application/opentype
                  application/x-opentype application/font-woff application/eot application/font application/font-sfnt
                  application/wasm application/javascript-binast application/manifest+json application/ld+json
-                 application/graphql+json application/geo+json;
+                 application/graphql+json application/geo+json 'application/vnd.ipld.car ; compress';
+
     # == end custom node directives ==
 
     include /etc/nginx/conf.d/*.conf;

--- a/container/shim/package-lock.json
+++ b/container/shim/package-lock.json
@@ -14,6 +14,8 @@
         "blockstore-core": "^1.0.5",
         "debug": "^4.3.4",
         "express": "^4.18.1",
+        "file-type": "^17.1.6",
+        "ipfs-unixfs": "^6.0.9",
         "ipfs-unixfs-exporter": "^7.0.11",
         "mime-types": "^2.1.35",
         "multiformats": "^9.7.0",
@@ -362,6 +364,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -2485,6 +2492,22 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "17.1.6",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.6.tgz",
+      "integrity": "sha512-hlDw5Ev+9e883s0pwUsuuYNu4tD7GgpUnOvykjv1Gya0ZIjuKumthDRua90VUn6/nlRKAjcxLUnHNTIUWwWIiw==",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0-alpha.9",
+        "token-types": "^5.0.0-alpha.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2947,6 +2970,25 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -4024,6 +4066,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
+      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -4233,6 +4287,34 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -4642,6 +4724,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4712,6 +4802,22 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
+      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -4812,6 +4918,22 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/touch": {
@@ -5048,6 +5170,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -5512,6 +5639,11 @@
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
+    },
+    "@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "@types/json-schema": {
       "version": "7.0.11",
@@ -7092,6 +7224,16 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-type": {
+      "version": "17.1.6",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.6.tgz",
+      "integrity": "sha512-hlDw5Ev+9e883s0pwUsuuYNu4tD7GgpUnOvykjv1Gya0ZIjuKumthDRua90VUn6/nlRKAjcxLUnHNTIUWwWIiw==",
+      "requires": {
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0-alpha.9",
+        "token-types": "^5.0.0-alpha.2"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -7427,6 +7569,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.2.0",
@@ -8216,6 +8363,11 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "peek-readable": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
+      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A=="
+    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -8361,6 +8513,24 @@
           "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
           "dev": true
         }
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
       }
     },
     "readdirp": {
@@ -8661,6 +8831,14 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -8714,6 +8892,15 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "strtok3": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
+      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.0.0"
+      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -8791,6 +8978,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
+    "token-types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      }
     },
     "touch": {
       "version": "3.1.0",
@@ -8968,6 +9164,11 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/container/shim/package.json
+++ b/container/shim/package.json
@@ -14,6 +14,8 @@
     "blockstore-core": "^1.0.5",
     "debug": "^4.3.4",
     "express": "^4.18.1",
+    "file-type": "^17.1.6",
+    "ipfs-unixfs": "^6.0.9",
     "ipfs-unixfs-exporter": "^7.0.11",
     "mime-types": "^2.1.35",
     "multiformats": "^9.7.0",

--- a/container/shim/src/utils/car_mimetype.js
+++ b/container/shim/src/utils/car_mimetype.js
@@ -1,0 +1,151 @@
+import { UnixFS } from 'ipfs-unixfs'
+import { fileTypeFromBuffer } from 'file-type'
+import * as dagCbor from '@ipld/dag-cbor'
+import * as dagPb from '@ipld/dag-pb'
+import * as dagJson from '@ipld/dag-json'
+import * as raw from 'multiformats/codecs/raw'
+import * as json from 'multiformats/codecs/json'
+
+class BlockIndexEntry {
+  constructor (type, data, links) {
+    this.type = type
+    this.data = data
+    this.links = links
+  }
+
+  hasLinks () {
+    return this.links.length > 0
+  }
+
+  isDirectory() {
+    return this.type === "directory"
+  }
+}
+
+class BlockIndex {
+  constructor() {
+    this.blockMap = {}
+    this.size = 0
+  }
+
+  addBlock(cid, entry) {
+    this.blockMap[cid] = entry
+    this.size++
+  }
+
+  getBlock(cid) {
+    return this.blockMap[cid]
+  }
+}
+
+class Block {
+  constructor(cid, bytes) {
+    const decoded = this.decode(cid, bytes)
+
+    this.dagDBRepresentation = decoded
+    this.unixFSRepresentation = UnixFS.unmarshal(bytes)
+  }
+
+  getType() {
+    return this.unixFSRepresentation.type
+  }
+
+  isFile() {
+    return this.getType() === "file"
+  }
+
+  getData() {
+    return this.unixFSRepresentation.data
+  }
+
+  hasLinks() {
+    return this.dagDBRepresentation.Links.length > 0
+  }
+
+  getLinks() {
+    return this.dagDBRepresentation.Links.map(link => link.Hash)
+  }
+
+  decode (cid, bytes) {
+    const codecs = {
+      [dagCbor.code]: dagCbor,
+      [dagPb.code]: dagPb,
+      [dagJson.code]: dagJson,
+      [raw.code]: raw,
+      [json.code]: json
+    }
+
+    if (!codecs[cid.code]) {
+      throw new Error(`Unknown codec code: 0x${cid.code.toString(16)}`)
+    }
+
+    return codecs[cid.code].decode(bytes)
+  }
+}
+
+export class CARMimeTypeRetriever {
+
+  constructor() {
+    this.blockIndex = new BlockIndex()
+  }
+
+  addBlock(cid, bytes) {
+    const block = new Block(cid, bytes)
+
+    let blockIndexEntry
+    if (block.isFile() && !block.hasLinks()) {
+      blockIndexEntry = new BlockIndexEntry(block.getType(), block.getData().subarray(0, 350), [])
+    } else {
+      blockIndexEntry = new BlockIndexEntry(block.getType(), null, block.getLinks())
+    }
+
+    this.blockIndex.addBlock(cid, blockIndexEntry)
+  }
+
+  async retrieveTypeForFile(cid) {
+    let currentBlock = cid;
+
+    let i = 0;
+    while(i < this.blockIndex.size) {
+      const blockIndexEntry = this.blockIndex.getBlock(currentBlock)
+
+      if (!blockIndexEntry.hasLinks()) {
+        const result = await fileTypeFromBuffer(blockIndexEntry.data)
+        if (result === undefined) {
+          throw Error("Mime type could be determined")
+        }
+
+        return result.mime
+      }
+
+      currentBlock = blockIndexEntry.links[0]
+      i += 1
+    }
+
+    throw Error("Mime type could not be determined")
+  }
+
+  async retrieveTypeForDirectory(links) {
+    const mimeTypes = []
+
+    for (const link of links) {
+      const result = await this.retrieveTypeForFile(link)
+      mimeTypes.push(result || undefined)
+    }
+
+    return mimeTypes
+  }
+
+  async retrieveType(cid) {
+    try {
+      const rootBlockIndexEntry = this.blockIndex.getBlock(cid)
+      if (rootBlockIndexEntry.isDirectory()) {
+        return await this.retrieveTypeForDirectory(rootBlockIndexEntry.links)
+      }
+
+      return [await this.retrieveTypeForFile(cid)]
+    } catch (error) {
+      return []
+    }
+  }
+}


### PR DESCRIPTION
Second part of #22.

The main idea to get the mime type of the file(s) is to:

1. Iterate over the blocks of the file
2. Index the X first bytes of every block
3. From the root block, traverse the tree to find out the first block of the file(s).

I have considered that the are three types of blocks.

1. `directory`: we're only interested in its `links` (i.e. the files that it points to)
2. `file` with links: in a large file, this blocks acts as a bridge to the data blocks of the file.
In this type of block, we're only interested in its `links` (it might point to another block withs links or actual data blocks)
3. `file` without links: the actual data blocks.

When we traverse the tree, we're looking for the first leftest data block. Then, from this block, we get the magic number of the file.

- The `CARMimeTypeRetriever` class indexes the X first bytes of every block (because we don't know what block is going to be the first leftest)
- The `CARMimeTypeRetriever.addBlock` method parses the bytes of the block by creating a `Block` object. Then, a `BlockIndexEntry` is included in the file (basically, a reduced version of a `Block`, which just contains the X first bytes).
- After iterating over the file, we call the `CARMimeTypeRetriever.retrieveType` method by passing the root CID. This method will iterate over the tree to find the first leftest block in the index.

Once we have the mime type, we need Nginx to conditionally compress the file. If the file has to be compressed, then a `Content-Type: application/vnd.ipld.car ; compress` header will be sent.

Things to consider:
1. Currently we are only considering that a directory can be in the root of the tree. Is it possible to have several directories? For example, a directory pointing to directories?
2. Error management: what happens if we can't determinate the mime type of a file? For example, plain text files won't have a mime type (e.g. txt).