### PR TITLE
proxy /ipns to the ipfs gateway, bypassing the shim altogether

### DIFF
--- a/container/nginx/confs/proxy.tlsconf
+++ b/container/nginx/confs/proxy.tlsconf
@@ -50,6 +50,21 @@ server {
         return 302 https://strn.network;
     }
 
+    location /ipns/ {
+        proxy_pass  https://ipfs.io;
+
+        if ($request_method = 'OPTIONS') {
+            add_header 'Timing-Allow-Origin'            '*';
+            add_header 'Access-Control-Allow-Origin'    '*';
+            add_header 'Access-Control-Allow-Methods'   'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers'   'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            add_header 'Access-Control-Max-Age'         1728000;
+            add_header 'Content-Type'                   'text/plain; charset=utf-8';
+            add_header 'Content-Length'                 0;
+            return 204;
+        }
+    }
+
     location / {
         if ($arg_clientId = "") {
             return 403;

--- a/container/shim/src/index.js
+++ b/container/shim/src/index.js
@@ -88,8 +88,6 @@ if (cluster.isPrimary) {
   })
 
   // Whenever nginx doesn't have a CAR file in cache, this is called
-  app.get('/ipns/:cid', handleCID)
-  app.get('/ipns/:cid/:path*', handleCID)
   app.get('/ipfs/:cid', handleCID)
   app.get('/ipfs/:cid/:path*', handleCID)
 


### PR DESCRIPTION
/ipns requests bypass the shim. Requests are still logged and reported.