### PR TITLE
Fix express async route handler. #33

### DIFF
--- a/container/shim/package-lock.json
+++ b/container/shim/package-lock.json
@@ -14,6 +14,7 @@
         "blockstore-core": "^1.0.5",
         "debug": "^4.3.4",
         "express": "^4.18.1",
+        "express-async-handler": "^1.2.0",
         "follow-redirects": "^1.15.1",
         "ipfs-unixfs-exporter": "^7.0.11",
         "mime-types": "^2.1.35",
@@ -2406,6 +2407,11 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-async-handler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
+      "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
@@ -7072,6 +7078,11 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
+    },
+    "express-async-handler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
+      "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/container/shim/package.json
+++ b/container/shim/package.json
@@ -14,6 +14,7 @@
     "blockstore-core": "^1.0.5",
     "debug": "^4.3.4",
     "express": "^4.18.1",
+    "express-async-handler": "^1.2.0",
     "follow-redirects": "^1.15.1",
     "ipfs-unixfs-exporter": "^7.0.11",
     "mime-types": "^2.1.35",

--- a/container/shim/src/index.js
+++ b/container/shim/src/index.js
@@ -4,6 +4,7 @@ import express from 'express'
 import mimeTypes from 'mime-types'
 import followRedirects from 'follow-redirects'
 import parseArgs from 'minimist'
+import asyncHandler from 'express-async-handler'
 
 import { addRegisterCheckRoute, deregister, register } from './modules/registration.js'
 import {
@@ -93,11 +94,7 @@ if (cluster.isPrimary) {
     res.sendStatus(404)
   })
 
-  // Whenever nginx doesn't have a CAR file in cache, this is called
-  app.get('/ipfs/:cid', handleCID)
-  app.get('/ipfs/:cid/:path*', handleCID)
-
-  async function handleCID (req, res) {
+  const handleCID = asyncHandler(async (req, res) => {
     const cid = req.params.cid
     const format = getResponseFormat(req)
 
@@ -183,7 +180,11 @@ if (cluster.isPrimary) {
         ipfsReq.destroy()
       }
     })
-  }
+  })
+
+  // Whenever nginx doesn't have a CAR file in cache, this is called
+  app.get('/ipfs/:cid', handleCID)
+  app.get('/ipfs/:cid/:path*', handleCID)
 
   addRegisterCheckRoute(app)
 


### PR DESCRIPTION
Until we decide in #33 how to replace `express`, secure the current implementation through https://www.npmjs.com/package/express-async-handler. I decided against the more popular https://www.npmjs.com/package/express-async-errors, because it patches express internals, which is inherently unsafe.