### PR TITLE
fix relative path to test car file

### DIFF
--- a/container/shim/src/index.js
+++ b/container/shim/src/index.js
@@ -1,5 +1,7 @@
 import fsPromises from 'node:fs/promises'
 import { cpus } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import express from 'express'
 import mimeTypes from 'mime-types'
 import followRedirects from 'follow-redirects'
@@ -84,7 +86,12 @@ if (cluster.isPrimary) {
 
   const app = express()
 
-  const testCAR = await fsPromises.readFile('./public/QmQ2r6iMNpky5f1m4cnm3Yqw8VSvjuKpTcK1X7dBR1LkJF.car')
+  const testCAR = await fsPromises.readFile(join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'public',
+    'QmQ2r6iMNpky5f1m4cnm3Yqw8VSvjuKpTcK1X7dBR1LkJF.car'
+  ))
 
   app.disable('x-powered-by')
   app.set('trust proxy', true)


### PR DESCRIPTION
Discovered during #51, trying to run the node process without docker.