### PR TITLE
Add basic test suite. Closes #49

### DIFF
--- a/container/shim/package-lock.json
+++ b/container/shim/package-lock.json
@@ -35,6 +35,7 @@
         "eslint-plugin-jsdoc": "^39.3.3",
         "eslint-plugin-promise": "^6.0.0",
         "husky": "^8.0.1",
+        "nock": "^13.2.9",
         "nodemon": "^2.0.18",
         "test": "^3.2.1"
       }
@@ -3487,6 +3488,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -3744,6 +3751,21 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.2.9",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
+      "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
       }
     },
     "node_modules/node-domexception": {
@@ -4136,6 +4158,15 @@
       "peer": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/protobufjs": {
@@ -7918,6 +7949,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -8115,6 +8152,18 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "nock": {
+      "version": "13.2.9",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
+      "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      }
     },
     "node-domexception": {
       "version": "1.0.0",
@@ -8378,6 +8427,12 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
       "peer": true
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "protobufjs": {
       "version": "6.11.3",

--- a/container/shim/package-lock.json
+++ b/container/shim/package-lock.json
@@ -35,7 +35,8 @@
         "eslint-plugin-jsdoc": "^39.3.3",
         "eslint-plugin-promise": "^6.0.0",
         "husky": "^8.0.1",
-        "nodemon": "^2.0.18"
+        "nodemon": "^2.0.18",
+        "test": "^3.2.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4723,6 +4724,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/string.prototype.replaceall": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.replaceall/-/string.prototype.replaceall-1.0.6.tgz",
+      "integrity": "sha512-OA8VDhE7ssNFlyoDXUHxw6V5cjgPrtosyJKqJX5i1P5tV9eUynsbhx1yz0g+Ye4fjFwAxhKLxt8GSRx2Aqc+Sw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.2",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
@@ -4845,6 +4863,21 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/test": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/test/-/test-3.2.1.tgz",
+      "integrity": "sha512-D9eN4OxdhyYS3xHSsAh5A0e+UhaOPxeREwBHTknZHoVFd4TqnPtkVrQ7lIUATPgpO9vvGg1D+TyMckVmUyaEig==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6",
+        "string.prototype.replaceall": "^1.0.6"
+      },
+      "bin": {
+        "node--test": "bin/node--test.js",
+        "node--test-only": "bin/node--test-only.js",
+        "test": "bin/node-core-test.js"
+      }
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -8777,6 +8810,20 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "string.prototype.replaceall": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.replaceall/-/string.prototype.replaceall-1.0.6.tgz",
+      "integrity": "sha512-OA8VDhE7ssNFlyoDXUHxw6V5cjgPrtosyJKqJX5i1P5tV9eUynsbhx1yz0g+Ye4fjFwAxhKLxt8GSRx2Aqc+Sw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.2",
+        "is-regex": "^1.1.4"
+      }
+    },
     "string.prototype.trimend": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
@@ -8869,6 +8916,16 @@
           "dev": true,
           "peer": true
         }
+      }
+    },
+    "test": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/test/-/test-3.2.1.tgz",
+      "integrity": "sha512-D9eN4OxdhyYS3xHSsAh5A0e+UhaOPxeREwBHTknZHoVFd4TqnPtkVrQ7lIUATPgpO9vvGg1D+TyMckVmUyaEig==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.6",
+        "string.prototype.replaceall": "^1.0.6"
       }
     },
     "text-table": {

--- a/container/shim/package.json
+++ b/container/shim/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "prepare": "cd ../.. && husky install container/shim/.husky",
-    "test": "eslint --fix ."
+    "test": "eslint --fix . && FIL_WALLET_ADDRESS=test NODE_OPERATOR_EMAIL=test node--test"
   },
   "dependencies": {
     "@ipld/car": "^4.1.3",
@@ -35,7 +35,8 @@
     "eslint-plugin-jsdoc": "^39.3.3",
     "eslint-plugin-promise": "^6.0.0",
     "husky": "^8.0.1",
-    "nodemon": "^2.0.18"
+    "nodemon": "^2.0.18",
+    "test": "^3.2.1"
   },
   "eslintConfig": {
     "extends": "ipfs",

--- a/container/shim/package.json
+++ b/container/shim/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-jsdoc": "^39.3.3",
     "eslint-plugin-promise": "^6.0.0",
     "husky": "^8.0.1",
+    "nock": "^13.2.9",
     "nodemon": "^2.0.18",
     "test": "^3.2.1"
   },

--- a/container/shim/package.json
+++ b/container/shim/package.json
@@ -5,7 +5,7 @@
     "prepare": "cd ../.. && husky install container/shim/.husky",
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint --fix .",
-    "test:unit": "FIL_WALLET_ADDRESS=test NODE_OPERATOR_EMAIL=test node--test"
+    "test:unit": "FIL_WALLET_ADDRESS=test NODE_OPERATOR_EMAIL=test L2_FIRE_AND_FORGET=true node--test"
   },
   "dependencies": {
     "@ipld/car": "^4.1.3",

--- a/container/shim/package.json
+++ b/container/shim/package.json
@@ -3,7 +3,9 @@
   "type": "module",
   "scripts": {
     "prepare": "cd ../.. && husky install container/shim/.husky",
-    "test": "eslint --fix . && FIL_WALLET_ADDRESS=test NODE_OPERATOR_EMAIL=test node--test"
+    "test": "npm run test:lint && npm run test:unit",
+    "test:lint": "eslint --fix .",
+    "test:unit": "FIL_WALLET_ADDRESS=test NODE_OPERATOR_EMAIL=test node--test"
   },
   "dependencies": {
     "@ipld/car": "^4.1.3",

--- a/container/shim/src/config.js
+++ b/container/shim/src/config.js
@@ -15,7 +15,9 @@ export const NODE_OPERATOR_EMAIL = process.env.NODE_OPERATOR_EMAIL || error('NOD
 export const IPFS_GATEWAY_ORIGIN = process.env.IPFS_GATEWAY_ORIGIN || 'https://ipfs.io'
 export const TESTING_CID = 'QmXjYBY478Cno4jzdCcPy4NcJYFrwHZ51xaCP8vUwN9MGm'
 export const nodeId = await readFile(NODE_ID_FILE_PATH, 'utf-8').catch(() => false) || createNodeId()
-export const L2_FIRE_AND_FORGET = SATURN_NETWORK === 'test'
+export const L2_FIRE_AND_FORGET = process.env.L2_FIRE_AND_FORGET
+  ? process.env.L2_FIRE_AND_FORGET === 'true'
+  : SATURN_NETWORK === 'test'
 
 export let nodeToken = ''
 export const updateNodeToken = (newToken) => { nodeToken = newToken }

--- a/container/shim/test/test.js
+++ b/container/shim/test/test.js
@@ -4,7 +4,7 @@ import app from '../src/index.js'
 import fetch from 'node-fetch'
 import http from 'node:http'
 import { promisify } from 'node:util'
-import { TESTING_CID } from '../src/config.js'
+import { DEV_VERSION, TESTING_CID, nodeId } from '../src/config.js'
 import fsPromises from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -36,6 +36,13 @@ test('L1 node', async t => {
           `${TESTING_CID}.car`
         ))
       )
+    })
+    await t.test('response headers', async t => {
+      const res = await fetch(`${address}/ipfs/${TESTING_CID}`)
+      assert.strictEqual(res.headers.get('content-type'), 'application/octet-stream')
+      assert.strictEqual(res.headers.get('cache-control'), 'public, max-age=31536000, immutable')
+      assert.strictEqual(res.headers.get('saturn-node-id'), nodeId)
+      assert.strictEqual(res.headers.get('saturn-node-version'), DEV_VERSION)
     })
   })
 

--- a/container/shim/test/test.js
+++ b/container/shim/test/test.js
@@ -60,7 +60,12 @@ test('L1 node', async t => {
         testCAR.subarray(10, 21)
       )
     })
+    await t.todo('respond from L2')
+    await t.todo('respond from ipfs gateway')
   })
+  await t.todo('GET /ipfs/:cid/:path*')
+  await t.todo('GET /register/:l2NodeId')
+  await t.todo('POST /data/:cid')
 
   server.close()
 })

--- a/container/shim/test/test.js
+++ b/container/shim/test/test.js
@@ -4,20 +4,16 @@ import app from '../src/index.js'
 import fetch, { Headers } from 'node-fetch'
 import http from 'node:http'
 import { promisify } from 'node:util'
-import { DEV_VERSION, TESTING_CID, nodeId } from '../src/config.js'
+import {
+  DEV_VERSION,
+  IPFS_GATEWAY_ORIGIN,
+  nodeId,
+  TESTING_CID
+} from '../src/config.js'
 import fsPromises from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import nock from 'nock'
-
-nock.disableNetConnect()
-nock.enableNetConnect('localhost')
-
-async function createServer () {
-  const server = http.createServer(app)
-  await promisify(server.listen.bind(server))()
-  return { server, address: `http://localhost:${server.address().port}` }
-}
 
 const testCAR = await fsPromises.readFile(join(
   dirname(fileURLToPath(import.meta.url)),
@@ -25,6 +21,19 @@ const testCAR = await fsPromises.readFile(join(
   'public',
   `${TESTING_CID}.car`
 ))
+
+nock.disableNetConnect()
+nock.enableNetConnect('localhost')
+
+nock(IPFS_GATEWAY_ORIGIN)
+  .get('/ipfs/CID')
+  .reply(200, testCAR)
+
+async function createServer () {
+  const server = http.createServer(app)
+  await promisify(server.listen.bind(server))()
+  return { server, address: `http://localhost:${server.address().port}` }
+}
 
 test('L1 node', async t => {
   const { server, address } = await createServer()
@@ -65,7 +74,24 @@ test('L1 node', async t => {
       )
     })
     await t.todo('respond from L2')
-    await t.todo('respond from ipfs gateway')
+    await t.test('respond from ipfs gateway', async t => {
+      await t.test('simple response', async t => {
+        const res = await fetch(`${address}/ipfs/CID`)
+        assert.strictEqual(res.status, 200)
+        assert.deepStrictEqual(
+          Buffer.from(await (await res.blob()).arrayBuffer()),
+          testCAR
+        )
+      })
+      await t.todo('formats')
+      await t.todo('?filename')
+      await t.todo('?download')
+      await t.todo('timeout')
+      await t.todo('user-agent')
+      await t.todo('bad gateway response')
+      await t.todo('proxy response headers')
+      await t.todo('premature request end')
+    })
   })
   await t.todo('GET /ipfs/:cid/:path*')
   await t.todo('GET /register/:l2NodeId')

--- a/container/shim/test/test.js
+++ b/container/shim/test/test.js
@@ -8,6 +8,10 @@ import { DEV_VERSION, TESTING_CID, nodeId } from '../src/config.js'
 import fsPromises from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import nock from 'nock'
+
+nock.disableNetConnect()
+nock.enableNetConnect('localhost')
 
 async function createServer () {
   const server = http.createServer(app)

--- a/container/shim/test/test.js
+++ b/container/shim/test/test.js
@@ -1,0 +1,23 @@
+import test from 'test'
+import assert from 'node:assert'
+import app from '../src/index.js'
+import fetch from 'node-fetch'
+import http from 'node:http'
+import { promisify } from 'node:util'
+
+async function createServer () {
+  const server = http.createServer(app)
+  await promisify(server.listen.bind(server))()
+  return { server, address: `http://localhost:${server.address().port}` }
+}
+
+test('L1 node', async t => {
+  const { server, address } = await createServer()
+
+  await t.test('GET /favicon.ico', async t => {
+    const res = await fetch(`${address}/favicon.ico`)
+    assert.strictEqual(res.status, 404)
+  })
+
+  server.close()
+})

--- a/container/shim/test/test.js
+++ b/container/shim/test/test.js
@@ -4,6 +4,10 @@ import app from '../src/index.js'
 import fetch from 'node-fetch'
 import http from 'node:http'
 import { promisify } from 'node:util'
+import { TESTING_CID } from '../src/config.js'
+import fsPromises from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 async function createServer () {
   const server = http.createServer(app)
@@ -17,6 +21,22 @@ test('L1 node', async t => {
   await t.test('GET /favicon.ico', async t => {
     const res = await fetch(`${address}/favicon.ico`)
     assert.strictEqual(res.status, 404)
+  })
+
+  await t.test('GET /ipfs/:cid', async t => {
+    await t.test('test CID', async t => {
+      const res = await fetch(`${address}/ipfs/${TESTING_CID}`)
+      assert.strictEqual(res.status, 200)
+      assert.deepStrictEqual(
+        Buffer.from(await (await res.blob()).arrayBuffer()),
+        await fsPromises.readFile(join(
+          dirname(fileURLToPath(import.meta.url)),
+          '..',
+          'public',
+          `${TESTING_CID}.car`
+        ))
+      )
+    })
   })
 
   server.close()


### PR DESCRIPTION
This PR adds a basic test suite, for the most important paths. It tests the HTTP server on the HTTP level, and mocks external resources.

I left a bunch of `todos` for tests that can be added in the future, and there are even more, but I first wanted to land the basic infrastructure and have a stable iteration platform.

The test runner used is [`test`](https://github.com/nodejs/node-core-test), which is a user-land port of the currently experimental [node core test runner](https://nodejs.org/api/test.html). I like using this module since it helps improve the node core module, and I think it will be very useful to have a solid test runner in node core.

Closes #49.