### PR TITLE
Disable `proxy_request_buffering`

### DIFF
--- a/container/nginx/confs/proxy.tlsconf
+++ b/container/nginx/confs/proxy.tlsconf
@@ -79,6 +79,7 @@ server {
         proxy_read_timeout          30m;
         proxy_connect_timeout       121s;
         proxy_ignore_client_abort   on;
+        proxy_request_buffering     off;
 
         proxy_set_header        Host                $host;
         proxy_set_header        X-Real-IP           $remote_addr;


### PR DESCRIPTION
Needs to be tested.

If this works, then it will significantly reduce L2 TTFB, as the whole response doesn't need to be buffered before handing it to the client.