### PR TITLE
Upgrade to http3 on all responses

### DIFF
--- a/container/nginx/confs/proxy.tlsconf
+++ b/container/nginx/confs/proxy.tlsconf
@@ -18,6 +18,8 @@ map $format_query $format_final {
     "raw"   "raw";
 }
 
+# The Alt-Svc header is used to negotiate HTTP/3
+# QUIC-Status is used to report HTTP3 usage back to the client
 server {
     listen 443 default_server ssl http2;
     listen 443 http3 reuseport;
@@ -49,11 +51,16 @@ server {
 
     location = / {
         add_header 'Strict-Transport-Security'      'max-age=63072000; includeSubDomains; preload' always;
+        add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
+        add_header QUIC-Status $http3;
         return 302 https://strn.network;
     }
 
     location ~ ^/(ipns|api)/ {
         proxy_pass  https://ipfs.io;
+
+        add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
+        add_header QUIC-Status $http3;
 
         if ($request_method = 'OPTIONS') {
             add_header 'Timing-Allow-Origin'            '*';
@@ -63,6 +70,8 @@ server {
             add_header 'Access-Control-Max-Age'         1728000;
             add_header 'Content-Type'                   'text/plain; charset=utf-8';
             add_header 'Content-Length'                 0;
+            add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
+            add_header QUIC-Status $http3;
             return 204;
         }
     }
@@ -106,9 +115,7 @@ server {
         add_header 'Access-Control-Allow-Headers'   'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
         add_header 'Access-Control-Expose-Headers'  '*' always;
         add_header 'Strict-Transport-Security'      'max-age=63072000; includeSubDomains; preload' always;
-        # Add Alt-Svc header to negotiate HTTP/3.
         add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
-        # Tell the client QUIC was used
         add_header QUIC-Status $http3;
 
         client_max_body_size 10g;
@@ -121,15 +128,21 @@ server {
             add_header 'Access-Control-Max-Age'         1728000;
             add_header 'Content-Type'                   'text/plain; charset=utf-8';
             add_header 'Content-Length'                 0;
+            add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
+            add_header QUIC-Status $http3;
             return 204;
         }
     }
 
     location ~* ^.*(QmPgVA4M2EGijWDtH59EYPSPXQhahsVUUytrs1wPJwpgBh|bafybeidgnebuxvarpnw2grmkgnamu6cv6|bafkreibk3n7kxz6ep4g6z6wr737jbd3upibwkzskp6olu7at7qa6bhrrc4|QmTuWjNEmtUd2HGqH5UJzBJ83EFE1yVLxsfgQvUmnFDdan|QmXg6yZZaehZuCzUmBQgfXQqsYF1vb1fJxaypXBPHPEXM7|bafkreibbogdqa6ikxpx56m2rcun3h5ygkrujhhqk6jgj3apwii6cgjpa4i|bafybeicp3x52jgy3qhsrwaioemeck7vhnryq2i2dgodkakkixuzruo54wa|bafybeigyoslufnbi5haonpc3yiktbpdyvas7mqprpvb7wx2jsqyyn65oau|bafybeiaywbhyg43vdl3kkgybpbczcijr2cy4me7tozmc23asq3q4l7znqi|bafybeiaq2wlk4yrt7xpvdzdcurssnxsgamzzvtjdlqkzr7mdhtfopdsmre|bafkreidvok3ip6owxv4npbwt2ok3eljtht7fkjttwwcbfo7nsfqodrarsa|bafybeihllbqrdebl75jrgjyp3o5f4thsyhrzoquqxbisvssfl5hxnxhbey|QmU31Zr3DdDkF2czLfupdYcCkG3rfnef6BsphuCGh4LY4m|QmbksLY3TWTNZw4TBSA7gQBEDSpXDSwEdMSPedxyzAjnnE).*$ {
+        add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
+        add_header QUIC-Status $http3;
         return 410;
     }
 
     location = /basic_status {
+        add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
+        add_header QUIC-Status $http3;
         stub_status;
     }
 }


### PR DESCRIPTION
- Given receiving alt-svc is required to upgrade to h3, let's try to allow clients to do it on all possible responses.