### PR TITLE
Replace BoringSSL with QuicTLS/OpenSSL

### DIFF
--- a/container/nginx/conf.d/shared.conf
+++ b/container/nginx/conf.d/shared.conf
@@ -4,6 +4,8 @@ limit_req   zone=one burst=200 nodelay;
 
 root  /usr/src/app/;
 
+# The Alt-Svc header is used to negotiate HTTP/3
+# QUIC-Status is used to report HTTP3 usage back to the client
 location = / {
     add_header 'Strict-Transport-Security'      'max-age=63072000; includeSubDomains; preload' always;
     add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';

--- a/container/nginx/confs/tls_proxy.conf
+++ b/container/nginx/confs/tls_proxy.conf
@@ -1,5 +1,3 @@
-# The Alt-Svc header is used to negotiate HTTP/3
-# QUIC-Status is used to report HTTP3 usage back to the client
 server {
     listen 443 default_server http3 reuseport;
     listen 443 default_server ssl http2 reuseport;


### PR DESCRIPTION
Given the change to http3 hurt our P50 TTFB, we should assess what caused that drop.

I can see two hypothesis:
  - the move from OpenSSL to BoringSSL (which this PR attempts to test);
  - changes in the nginx core itself which we can't really assess for ourselves (at least without taking quite some time looking into them), but which we can disable.

I would try this first and see what happens. If our metrics don't recover, then we can simply disable the whole thing.
If disabling the whole thing doesn't work, then we can revert to previous image setup (which will give us our metrics back for sure)