### PR TITLE
Group package installs on the final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,10 +114,10 @@ COPY --from=build /usr/src/openssl/build/lib/libcrypto.so.81.3 /usr/lib/nginx/mo
 COPY --from=build /usr/src/${NGINX_NAME}/objs/ngx_http_brotli_filter_module.so /usr/lib/nginx/modules/
 COPY --from=build /usr/src/${NGINX_NAME}/objs/ngx_http_brotli_static_module.so /usr/lib/nginx/modules/
 
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 # RUN curl -fsSL https://install.speedtest.net/app/cli/install.deb.sh | bash -
-RUN curl -fsSL https://packagecloud.io/install/repositories/ookla/speedtest-cli/script.deb.sh | bash -
-RUN apt-get install --no-install-recommends -y \
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+ && curl -fsSL https://packagecloud.io/install/repositories/ookla/speedtest-cli/script.deb.sh | bash - \
+ && apt-get install --no-install-recommends -y \
    nodejs \
    speedtest \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
When looking for other things to optimise for http3, I noticed our image size could be smaller.

For efficiency's sake, I reduce the number of layers on the final image and that got us from 334MB till 314MB which is a 6% saving.
It's not a lot, but it's something.

I also tried to group the `npm ci` command but that didn't produce any savings, so I left it in its place for readability.