### PR TITLE
Support Ansible-backed deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ on [Filecoin Slack](https://filecoinproject.slack.com/)!
 
    **Make sure to have env variables set in `/etc/environment` or hardcoded in `update.sh` for auto-update to work**
 
+## Running a node with Ansible
+
+Note these instructions are to be run in a machine where Ansible is installed. This should not be your L1 node target deployment machine.
+
+1. Clone this repository and `cd` into it.
+
+2. Export the `FIL_WALLET_ADDRESS`, `NODE_OPERATOR_EMAIL,` and `SATURN_NETWORK` env variables.
+  - If **Main network:** Set `SATURN_NETWORK` to `main`
+
+3. Run `ansible-playbook -i <path_to_your_inventory> --extra-vars targets=all playbooks/l1.yaml`
+  - Make sure to specify which hosts you want to provision in your inventory file.
+  - Feel free to use labels (modify the `targets` var) to filter them or to deploy incrementally.
+
 ## Stopping a node
 
 To gracefully stop a node a not receive a penalty, run:

--- a/README.md
+++ b/README.md
@@ -87,16 +87,19 @@ on [Filecoin Slack](https://filecoinproject.slack.com/)!
 
 ## Running a node with Ansible
 
-Note these instructions are to be run in a machine where Ansible is installed. This should not be your L1 node target deployment machine.
+Note: these instructions are to be run in a machine where Ansible is installed.
+This should not be your L1 node target deployment machine.
+This machine should have ssh access to the target machine.
 
 1. Clone this repository and `cd` into it.
 
 2. Export the `FIL_WALLET_ADDRESS`, `NODE_OPERATOR_EMAIL,` and `SATURN_NETWORK` env variables.
   - If **Main network:** Set `SATURN_NETWORK` to `main`
 
-3. Run `ansible-playbook -i <path_to_your_inventory> --extra-vars targets=all playbooks/l1.yaml`
+3. Run `ansible-playbook -i <path_to_your_inventory> --extra-vars targets=all --skip-tags=bootstrap playbooks/l1.yaml`
   - Make sure to specify which hosts you want to provision in your inventory file.
   - Feel free to use labels (modify the `targets` var) to filter them or to deploy incrementally.
+  - We're skipping the bootstrap play by default, as it deals with setting authorized keys on the target machine.
 
 ## Stopping a node
 

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -1,5 +1,6 @@
 ---
 - name: Bootstrap playbook
+  tags: bootstrap
   hosts: "{{ targets }}"
   # https://stackoverflow.com/questions/32297456/how-to-ignore-ansible-ssh-authenticity-checking/54735937#54735937
   # Don't gather facts automatically because that will trigger

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -77,7 +77,7 @@
   hosts: "{{ targets }}"
   vars:
     env_vars:
-      SATURN_NETWORK: "{{ lookup('ansible.builtin.env', 'SATURN_NETWORK', default=undef()) }}"
+      SATURN_NETWORK: "{{ lookup('ansible.builtin.env', 'SATURN_NETWORK', default='test') }}"
       FIL_WALLET_ADDRESS: "{{ lookup('ansible.builtin.env', 'FIL_WALLET_ADDRESS', default=undef()) }}"
       NODE_OPERATOR_EMAIL: "{{ lookup('ansible.builtin.env', 'NODE_OPERATOR_EMAIL', default=undef()) }}"
     # this wasn't consistent between runs, so we need to store it

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -105,21 +105,17 @@
         https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/run.sh
       dest: "{{ homedir }}/run.sh"
       mode: +x
-  - name: Run the L1 container
-    docker_container:
+  - name: Check the L1 container
+    become: true
+    become_user: root
+    docker_container_info:
       name: saturn-node
-      image: "ghcr.io/filecoin-saturn/l1-node:{{ env_vars.SATURN_NETWORK }}"
-      interactive: true
-      tty: true
-      detach: true
-      restart_policy: unless-stopped
-      network_mode: host
-      env: "{{ env_vars }}"
-      volumes:
-      - "{{ saturn_home }}/shared:/usr/src/app/shared"
-      state: started
-      # ignoring this, so there are no unneeded restarts on auto-update
-      ignore_image: true
+    register: saturn_container
+  - name: Run the L1 container
+    become: true
+    become_user: root
+    command: "{{ homedir }}/run.sh"
+    when: not saturn_container.exists
   - name: Download the update.sh file
     become: true
     become_user: root

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -115,7 +115,7 @@
   - name: Run the L1 container
     become: true
     become_user: root
-    command: "{{ homedir }}/run.sh"
+    ansible.builtin.shell: "{{ homedir }}/run.sh"
     when: not saturn_container.exists
   - name: Download the update.sh file
     become: true

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -1,0 +1,139 @@
+---
+- name: Bootstrap playbook
+  hosts: "{{ targets }}"
+  # https://stackoverflow.com/questions/32297456/how-to-ignore-ansible-ssh-authenticity-checking/54735937#54735937
+  # Don't gather facts automatically because that will trigger
+  # a connection, which needs to check the remote host key
+  gather_facts: false
+  tasks:
+  - name: Check known_hosts for {{ inventory_hostname }}
+    delegate_to: localhost
+    command: ssh-keygen -F {{ inventory_hostname }}
+    register: has_entry_in_known_hosts_file
+    changed_when: false
+    ignore_errors: true
+  - name: Ignore host key for {{ inventory_hostname }} on first run
+    when: has_entry_in_known_hosts_file.rc == 1
+    set_fact:
+      ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
+  # Now that we have resolved the issue with the host key
+  # we can "gather facts" without issue
+  - name: Set authorized keys for the host
+    authorized_key:
+      user: "{{ ansible_user }}"
+      state: present
+      key: "{{ lookup('file', '../authorized_keys') }}"
+- name: Configure playbook
+  hosts: "{{ targets }}"
+  gather_facts: true
+  vars:
+    packages:
+      docker:
+        CentOS: docker-ce
+        Ubuntu: docker.io
+      pip:
+        CentOS: python3-pip.noarch
+        Ubuntu: python3-pip
+  tasks:
+  - name: Add docker repository
+    become: true
+    become_user: root
+    # ref - https://www.ansiblepilot.com/articles/install-docker-in-redhat-like-systems-ansible-module-rpm_key-yum_repository-and-yum/
+    ansible.builtin.yum_repository:
+      name: docker
+      description: docker repository to CentOS
+      baseurl: "https://download.docker.com/linux/centos/$releasever/$basearch/stable"
+      enabled: true
+      gpgcheck: true
+      gpgkey: "https://download.docker.com/linux/centos/gpg"
+      state: present
+    when: ansible_distribution == "CentOS"
+  - name: Install OS packages
+    become: true
+    become_user: root
+    ansible.builtin.package:
+      name:
+      - wget
+      - "{{ packages.docker[ansible_distribution] }}"
+      - "{{ packages.pip[ansible_distribution] }}"
+      state: present
+      update_cache: true
+  - name: Install python packages
+    become: true
+    become_user: root
+    ansible.builtin.pip:
+      executable: pip3
+      name:
+      - docker>5.0.0
+      state: present
+  - name: Start docker
+    become: true
+    become_user: root
+    ansible.builtin.service:
+      name: docker
+      enabled: true
+      state: started
+- name: Run playbook
+  hosts: "{{ targets }}"
+  vars:
+    env_vars:
+      SATURN_NETWORK: "{{ lookup('ansible.builtin.env', 'SATURN_NETWORK', default=undef()) }}"
+      FIL_WALLET_ADDRESS: "{{ lookup('ansible.builtin.env', 'FIL_WALLET_ADDRESS', default=undef()) }}"
+      NODE_OPERATOR_EMAIL: "{{ lookup('ansible.builtin.env', 'NODE_OPERATOR_EMAIL', default=undef()) }}"
+    # this wasn't consistent between runs, so we need to store it
+    homedir: "{{ ansible_env.HOME }}"
+    saturn_home: "{{ volume_root if volume_root is defined else homedir }}"
+  tasks:
+  - name: Print the homedir
+    ansible.builtin.debug:
+      var: homedir
+  - name: Set L1 container env
+    become: true
+    become_user: root
+    blockinfile:
+      dest: "{{ item.0 }}"
+      block: export {{ item.1.key }}={{ item.1.value }}
+      marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.1.key }}"
+    with_nested:
+    - [/etc/environment, "{{ homedir }}/.bashrc"]
+    - "{{ env_vars | dict2items + [{'key': 'SATURN_HOME', 'value': saturn_home}] }}"
+  - name: Get the L1 run.sh script
+    become: true
+    become_user: root
+    ansible.builtin.get_url:
+      url: |
+        https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/run.sh
+      dest: "{{ homedir }}/run.sh"
+      mode: +x
+  - name: Run the L1 container
+    docker_container:
+      name: saturn-node
+      image: "ghcr.io/filecoin-saturn/l1-node:{{ env_vars.SATURN_NETWORK }}"
+      interactive: true
+      tty: true
+      detach: true
+      restart_policy: unless-stopped
+      network_mode: host
+      env: "{{ env_vars }}"
+      volumes:
+      - "{{ saturn_home }}/shared:/usr/src/app/shared"
+      state: started
+      # ignoring this, so there are no unneeded restarts on auto-update
+      ignore_image: true
+  - name: Download the update.sh file
+    become: true
+    become_user: root
+    ansible.builtin.get_url:
+      url: |
+        https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/update.sh
+      dest: "{{ homedir }}/update.sh"
+      mode: +x
+  - name: Creates the L1 update cron job
+    become: true
+    become_user: root
+    ansible.builtin.cron:
+      name: l1-update
+      minute: "*/5"
+      user: root
+      job: "{{ homedir }}/update.sh >> {{ homedir }}/l1-cron.log"
+      state: present


### PR DESCRIPTION
This is an automated way for L1 runners to provision their servers. With this approach, one can deploy multiple servers at once following exactly the same process, removing toil and human error.

I tried to mimic the instructions to run a node as close as possible.

This PR adds `playbooks/l1.yaml` and instructions on how to run that playbook.
More playbooks can be added over time to support any maintenance/upgrade operations which might be needed.