### PR TITLE
Use quiche as the quic implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ ARG CONFIG="--prefix=/etc/nginx \
 FROM debian AS build
 
 ARG NGINX_VERSION
+ARG NGINX_BRANCH=quic
 # https://hg.nginx.org/nginx-quic/shortlog/quic
 ARG NGINX_COMMIT=98e94553ae51
 # https://github.com/google/ngx_brotli
@@ -89,8 +90,8 @@ RUN echo "Cloning and building quictls $QUICTLS_COMMIT" \
  && make \
  && make install
 
-RUN echo "Cloning nginx and building $NGINX_VERSION (rev $NGINX_COMMIT from 'quic' branch)" \
- && hg clone -b quic --rev $NGINX_COMMIT https://hg.nginx.org/nginx-quic /usr/src/nginx-$NGINX_VERSION \
+RUN echo "Cloning nginx and building $NGINX_VERSION (rev $NGINX_COMMIT from '$NGINX_BRANCH' branch)" \
+ && hg clone -b $NGINX_BRANCH --rev $NGINX_COMMIT https://hg.nginx.org/nginx-quic /usr/src/nginx-$NGINX_VERSION \
  && cd /usr/src/nginx-$NGINX_VERSION \
  && ./auto/configure $CONFIG \
   --with-cc-opt="-I../openssl/build/include" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
 ARG NGINX_VERSION="1.23.1"
 ARG NGINX_NAME="nginx-${NGINX_VERSION}"
 
+FROM debian AS build
+
+ARG NGINX_VERSION
+# https://hg.nginx.org/nginx
+ARG NGINX_BRANCH=default
+ARG NGINX_COMMIT=ba5cf8f73a2d
+# https://github.com/cloudflare/quiche
+ARG QUICHE_COMMIT=2d512e92f81d98b4369bfe67c1365de118169081
+# https://github.com/google/ngx_brotli
+ARG NGX_BROTLI_COMMIT=6e975bcb015f62e1f303054897783355e2a877dc
+# https://github.com/quictls/openssl
+ARG QUICTLS_COMMIT=75e940831d0570d6b020cfebf128ae500f424867
 ARG CONFIG="--prefix=/etc/nginx \
  --sbin-path=/usr/sbin/nginx \
  --modules-path=/usr/lib/nginx/modules \
@@ -29,7 +41,8 @@ ARG CONFIG="--prefix=/etc/nginx \
  --with-http_sub_module \
  --with-http_v2_module \
  --with-http_v3_module \
- --with-stream_quic_module \
+ --with-openssl=/usr/src/quiche/quiche/deps/boringssl \
+ --with-quiche=/usr/src/quiche \
  --with-mail \
  --with-mail_ssl_module \
  --with-stream \
@@ -39,19 +52,8 @@ ARG CONFIG="--prefix=/etc/nginx \
  --with-compat \
  --add-dynamic-module=/usr/src/ngx_brotli"
 
-FROM debian AS build
-
-ARG NGINX_VERSION
-ARG NGINX_BRANCH=quic
-# https://hg.nginx.org/nginx-quic/shortlog/quic
-ARG NGINX_COMMIT=98e94553ae51
-# https://github.com/google/ngx_brotli
-ARG NGX_BROTLI_COMMIT=6e975bcb015f62e1f303054897783355e2a877dc
-# https://github.com/quictls/openssl
-ARG QUICTLS_COMMIT=75e940831d0570d6b020cfebf128ae500f424867
-ARG CONFIG
-
 # Install dependencies
+# we need an up-to-date cargo
 RUN apt-get update && apt-get install -y \
   dpkg-dev \
   build-essential \
@@ -68,7 +70,8 @@ RUN apt-get update && apt-get install -y \
   unzip \
   wget \
   libxslt-dev \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 WORKDIR /usr/src
 
@@ -81,21 +84,23 @@ RUN echo "Cloning brotli $NGX_BROTLI_COMMIT" \
  && git checkout --recurse-submodules -q FETCH_HEAD \
  && git submodule update --init --depth 1
 
-RUN echo "Cloning and building quictls $QUICTLS_COMMIT" \
+# using boringssl here
+RUN echo "Cloning and getting the quiche patches $QUICHE_COMMIT" \
+ && git clone --recursive https://github.com/cloudflare/quiche \
+ && cd /usr/src/quiche \
+ && git checkout --recurse-submodules $QUICHE_COMMIT \
  && cd /usr/src \
- && git clone https://github.com/quictls/openssl \
- && cd openssl \
- && git checkout $QUICTLS_COMMIT \
- && ./config shared --prefix=/usr/src/openssl/build --openssldir=/usr/src/openssl/build --libdir=lib \
- && make \
- && make install
+ && wget -q https://raw.githubusercontent.com/kn007/patch/1062e64ead7e1b21a52392cdd02d1d5bc631d231/nginx_with_quic.patch \
+ && wget -q https://raw.githubusercontent.com/kn007/patch/cd03b77647c9bf7179acac0125151a0fbb4ac7c8/Enable_BoringSSL_OCSP.patch
 
+ENV PATH="/root/.cargo/bin:$PATH"
 RUN echo "Cloning nginx and building $NGINX_VERSION (rev $NGINX_COMMIT from '$NGINX_BRANCH' branch)" \
  && hg clone -b $NGINX_BRANCH --rev $NGINX_COMMIT https://hg.nginx.org/nginx-quic /usr/src/nginx-$NGINX_VERSION \
  && cd /usr/src/nginx-$NGINX_VERSION \
- && ./auto/configure $CONFIG \
-  --with-cc-opt="-I../openssl/build/include" \
-  --with-ld-opt="-L../openssl/build/lib" \
+ && patch -p01 < /usr/src/nginx_with_quic.patch \
+ && patch -p01 < /usr/src/Enable_BoringSSL_OCSP.patch \
+ && echo "[net]\ngit-fetch-with-cli = true" > /root/.cargo/config.toml \
+ && ./auto/configure $CONFIG --build="quiche-$(git --git-dir=/usr/src/quiche/.git rev-parse --short HEAD)" \
  && make \
  && make install
 
@@ -104,8 +109,6 @@ FROM nginx:${NGINX_VERSION}
 ARG NGINX_NAME
 
 COPY --from=build /usr/sbin/nginx /usr/sbin/
-COPY --from=build /usr/src/openssl/build/lib/libssl.so.81.3 /usr/lib/nginx/modules/
-COPY --from=build /usr/src/openssl/build/lib/libcrypto.so.81.3 /usr/lib/nginx/modules/
 COPY --from=build /usr/src/${NGINX_NAME}/objs/ngx_http_brotli_filter_module.so /usr/lib/nginx/modules/
 COPY --from=build /usr/src/${NGINX_NAME}/objs/ngx_http_brotli_static_module.so /usr/lib/nginx/modules/
 

--- a/container/nginx/confs/tls_proxy.conf
+++ b/container/nginx/confs/tls_proxy.conf
@@ -1,5 +1,5 @@
 server {
-    listen 443 default_server http3 reuseport;
+    listen 443 default_server quic reuseport;
     listen 443 default_server ssl http2 reuseport;
 
     ssl_certificate             /usr/src/app/shared/ssl/node.crt;
@@ -11,8 +11,6 @@ server {
     ssl_session_timeout         365d;
     ssl_session_tickets         off;
     ssl_buffer_size             4k;
-    ssl_stapling                on;
-    ssl_stapling_verify         on;
     ssl_trusted_certificate     /usr/src/app/shared/ssl/node.crt;
     ssl_early_data              on;
 


### PR DESCRIPTION
This is an attempt at using a more battle-hardened and actively developed quic implementation. Hopefully this will bring us better TTFB performance.
One drawback is that this brings back BoringSSL and that disables OCSP stapling (we can enable it, but we need to manage the `ssl_stapling_file` manually. More info on how this matters [here](https://markvanlent.dev/2014/04/19/ocsp-stapling-in-nginx/)). Cloudflare has a bunch of things to say about BoringSSL [here](https://blog.cloudflare.com/make-ssl-boring-again/).

My approach was heavily based on https://github.com/patrikjuvonen/docker-nginx-http3/:
- Installed rust so we get the latest cargo and things build as they should (had issues with the stock Debian version);
- Got the two patches: one for OCSP+BoringSSL (AFAICT this enables `ssl_stapling_file`) and the important [one](https://raw.githubusercontent.com/kn007/patch/1062e64ead7e1b21a52392cdd02d1d5bc631d231/nginx_with_quic.patch) which joins nginx and quiche into a happy http3 delivery machine (or so I hope).
- Built nginx with these patches.
- Tweaked the nginx config so it works with quiche.

Maintainability-wise this is a harder path to walk in, as we'll relying on 3rd party patches. This could be, however, a sweet spot until nginx releases official quic support.

Let me know if this makes sense!