### PR TITLE
Enable quic address validation

### DIFF
--- a/container/nginx/confs/tls_proxy.conf
+++ b/container/nginx/confs/tls_proxy.conf
@@ -16,6 +16,8 @@ server {
     ssl_trusted_certificate     /usr/src/app/shared/ssl/node.crt;
     ssl_early_data              on;
 
+    quic_retry on;
+
     resolver    8.8.8.8 1.1.1.1 valid=600s;
 
     server_name _; # This is just an invalid value which will never trigger on a real hostname


### PR DESCRIPTION
The rationale for this is to experiment and hopefully lower the number of "quic no available client ids for new path while handling decrypted packet", as those might be having in impact in perceived performance.

According to https://quic.nginx.org/readme.html, `quic_retry on;` enable quic address validation. After skimming through this partially-related [RFC](https://www.ietf.org/id/draft-ietf-quic-retry-offload-00.html), one can read "QUIC uses Retry packets to reduce load on stressed servers, by forcing the client to prove ownership of its address before the server commits state. QUIC also has an anti-tampering mechanism to prevent the unauthorized injection of Retry packets into a connection".

This seems related enough to the error to warrant a try. My hypothesis is that with address validation, we'll end up getting less QUIC connection migration (term used by the nginx developers) errors and that that will improve TTFB performance. I might be totally wrong here however, as it may happen that these concerns are orthogonal.

Let me know what you think!