### PR TITLE
Disable http3 support (for now)

### DIFF
--- a/container/nginx/conf.d/shared.conf
+++ b/container/nginx/conf.d/shared.conf
@@ -4,20 +4,13 @@ limit_req   zone=one burst=200 nodelay;
 
 root  /usr/src/app/;
 
-# The Alt-Svc header is used to negotiate HTTP/3
-# QUIC-Status is used to report HTTP3 usage back to the client
 location = / {
     add_header 'Strict-Transport-Security'      'max-age=63072000; includeSubDomains; preload' always;
-    add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
-    add_header QUIC-Status $http3;
     return 302 https://strn.network;
 }
 
 location ~ ^/(ipns|api)/ {
     proxy_pass  https://ipfs.io;
-
-    add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
-    add_header QUIC-Status $http3;
 
     if ($request_method = 'OPTIONS') {
         add_header 'Timing-Allow-Origin'            '*';
@@ -27,8 +20,6 @@ location ~ ^/(ipns|api)/ {
         add_header 'Access-Control-Max-Age'         1728000;
         add_header 'Content-Type'                   'text/plain; charset=utf-8';
         add_header 'Content-Length'                 0;
-        add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
-        add_header QUIC-Status $http3;
         return 204;
     }
 }
@@ -73,8 +64,6 @@ location / {
     add_header 'Access-Control-Allow-Headers'   'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
     add_header 'Access-Control-Expose-Headers'  '*' always;
     add_header 'Strict-Transport-Security'      'max-age=63072000; includeSubDomains; preload' always;
-    add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
-    add_header QUIC-Status $http3;
 
     client_max_body_size 10g;
 
@@ -87,8 +76,6 @@ location / {
         add_header 'Access-Control-Max-Age'         1728000;
         add_header 'Content-Type'                   'text/plain; charset=utf-8';
         add_header 'Content-Length'                 0;
-        add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
-        add_header QUIC-Status $http3;
         return 204;
     }
 
@@ -98,8 +85,6 @@ location / {
 }
 
 location = /basic_status {
-    add_header Alt-Svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
-    add_header QUIC-Status $http3;
     stub_status;
 }
 

--- a/container/nginx/confs/tls_proxy.conf
+++ b/container/nginx/confs/tls_proxy.conf
@@ -1,5 +1,4 @@
 server {
-    listen 443 default_server quic reuseport;
     listen 443 default_server ssl http2 reuseport;
 
     ssl_certificate             /usr/src/app/shared/ssl/node.crt;

--- a/container/nginx/nginx.conf
+++ b/container/nginx/nginx.conf
@@ -38,7 +38,7 @@ http {
                     '&&rt=$request_time&&addr=$remote_addr&&ff=$http_x_forwarded_for'
                     '&&ref=$http_referer&&uct=$upstream_connect_time&&uht=$upstream_header_time'
                     '&&urt=$upstream_response_time&&ucs=$upstream_cache_status'
-                    '&&h3=$http3&&sp=$server_protocol&&host=$http_host';
+                    '&&sp=$server_protocol&&host=$http_host';
 
     limit_req_zone      $binary_remote_addr zone=one:100m rate=100r/s;
     limit_req_status    429;


### PR DESCRIPTION
Following our tests with http3, I think it's safe to conclude data-wise that http2 is presently a better option in terms of TTFB.

The reasons for this conclusion aren't entirely apparent, but my current guess is that this is a matter of implementation performance (in the case of nginx-quic with boringssl/openssl) and/or integration shortcomings (nginx+quiche).
I should also note the lack of OCSP stapling might have been a performance degrading factor for the options which use boringssl.

In terms of perceived performance I would rank the different options as follows (DESC):
- nginx-quic with openssl/quictls
- nginx-quic with boringssl
- nginx+quiche with boringssl

I wished to try nginx+quiche with openssl/quictls, but that doesn't seem to be an option right now.

Given all this I propose we go back to http2-land and see if we recover our pre-http3 TTFB.
- If that does not happen then we might be in the face of a confounding variable which we need to identify;
- If it happen does then I propose we revisit http3 when nginx releases official support for it.

Hope this rationale makes sense! Let me know if I should dig deeper into other approaches.
Also note that I didn't disable http3 support on the log ingestor's side, as I'm thinking that won't hurt. Let me know if you think it should be removed as well.