### PR TITLE
Improve the Ansible readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ on [Filecoin Slack](https://filecoinproject.slack.com/)!
 From [here](https://docs.ansible.com/ansible/latest/index.html#about-ansible):
 > "Ansible is an IT automation tool. It can configure systems, deploy software, and orchestrate more advanced IT tasks such as continuous deployments or zero downtime rolling updates."
 
-This playbook is meant as a bare-bones approach to running an L1. It simply automates running the steps described [above](## Running a node). A consequence of this is that when run this playbook will restart a crashed L1 node docker container.
+This playbook is meant as a bare-bones approach to running an L1. It simply automates running the steps described [above](#running-a-node). A consequence of this is that when run this playbook will restart a crashed L1 node docker container.
 Note: this does not cover server hardening and you should do your own research to ensure your server follows security best practices.
 
 Currently, this playbook runs on the following Linux distros:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ on [Filecoin Slack](https://filecoinproject.slack.com/)!
 
 ## Running a node with [Ansible](https://docs.ansible.com/ansible/latest/index.html)
 
-This playbook is meant as a bare-bones approach to running an L1. It simply automates running the steps described [above](## Running a node).
+This playbook is meant as a bare-bones approach to running an L1. It simply automates running the steps described [above](## Running a node). A consequence of this is that when run this playbook will restart a crashed L1 node docker container.
 Note: this does not cover server hardening and you should do your own research to ensure your server follows security best practices.
 
 Currently, this playbook runs on the following Linux distros:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Most commands are run as root and your ssh user should have root access on the t
 
 4. Replace the env var values where appropriate and export them.
   - If **Main network:** Set `SATURN_NETWORK` to `main`
-  - If moving either to the **main** or **test** networks change the `SATURN_NETWORK` value appropriately and run step 4 and 5.
+  - If you are switching networks check [Switching networks](#switching-networks) and rerun step 4 and 5.
 
   ```
   export FIL_WALLET_ADDRESS=<your_fil_wallet_address>; export NODE_OPERATOR_EMAIL=<your_email>; export SATURN_NETWORK=test

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ on [Filecoin Slack](https://filecoinproject.slack.com/)!
 
 ## Running a node with [Ansible](https://docs.ansible.com/ansible/latest/index.html)
 
+From [here](https://docs.ansible.com/ansible/latest/index.html#about-ansible):
+> "Ansible is an IT automation tool. It can configure systems, deploy software, and orchestrate more advanced IT tasks such as continuous deployments or zero downtime rolling updates."
+
 This playbook is meant as a bare-bones approach to running an L1. It simply automates running the steps described [above](## Running a node). A consequence of this is that when run this playbook will restart a crashed L1 node docker container.
 Note: this does not cover server hardening and you should do your own research to ensure your server follows security best practices.
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ This playbook is meant as a bare-bones approach to running an L1. These instruct
 
 Currently, this playbook runs on the following Linux distros:
   - Ubuntu
+  - Debian
   - CentOS
 
 1. Clone this repository and `cd` into it.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Most commands are run as root and your ssh user should have root access on the t
 
 3. Replace the env var values where appropriate and export them.
   - If **Main network:** Set `SATURN_NETWORK` to `main`
+  - If moving either to the **main** or **test** networks change the `SATURN_NETWORK` value appropriately and run step 3 and 4.
 
   ```
   export FIL_WALLET_ADDRESS=<your_fil_wallet_address>; export NODE_OPERATOR_EMAIL=<your_email>; export SATURN_NETWORK=test

--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ on [Filecoin Slack](https://filecoinproject.slack.com/)!
 
 ## Running a node with Ansible
 
-This playbook is meant as a bare-bones approach to running an L1. These instructions are to be run in a machine with [Ansible](https://docs.ansible.com/ansible/latest/index.html) >= 2.12 installed.
+This playbook is meant as a bare-bones approach to running an L1. It simply automates running the steps described [above](## Running a node).
+Note: this does not cover server hardening and you should do your own research to ensure your server follows security best practices.
+
+These instructions are to be run in a machine with [Ansible](https://docs.ansible.com/ansible/latest/index.html) >= 2.12 installed (aka control node).
   - This machine should not be your L1 node target deployment machine.
   - This machine should have ssh access to the said target machine.
 

--- a/README.md
+++ b/README.md
@@ -87,31 +87,43 @@ on [Filecoin Slack](https://filecoinproject.slack.com/)!
 
    **Make sure to have env variables set in `/etc/environment` for auto-update to work**
 
-## Running a node with Ansible
+## Running a node with [Ansible](https://docs.ansible.com/ansible/latest/index.html)
 
 This playbook is meant as a bare-bones approach to running an L1. It simply automates running the steps described [above](## Running a node).
 Note: this does not cover server hardening and you should do your own research to ensure your server follows security best practices.
-
-These instructions are to be run in a machine with [Ansible](https://docs.ansible.com/ansible/latest/index.html) >= 2.12 installed (aka control node).
-  - This machine should not be your L1 node target deployment machine.
-  - This machine should have ssh access to the said target machine.
 
 Currently, this playbook runs on the following Linux distros:
   - Ubuntu
   - Debian
   - CentOS
 
-1. Clone this repository and `cd` into it.
+These instructions are to be run in a machine with [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) >= 2.12 installed.
+  - This machine is known as your control node and it should not be the one to run your L1 node.
 
-2. Run `export FIL_WALLET_ADDRESS=<your_fil_wallet_address>; export NODE_OPERATOR_EMAIL=<your_email>; export SATURN_NETWORK=test`
-  - Replace the env var values where appropriate.
+1. Ensure your control node has ssh access to your target machine.
+
+  ```
+  ansible -vvv -i <path_to_your_inventory> <host_label> -m ping
+  ```
+
+2. Clone this repository and `cd` into it.
+
+3. Replace the env var values where appropriate and export them.
   - If **Main network:** Set `SATURN_NETWORK` to `main`
 
-3. Run `ansible-playbook -i <path_to_your_inventory> --extra-vars targets=all --skip-tags=bootstrap playbooks/l1.yaml`
+  ```
+  export FIL_WALLET_ADDRESS=<your_fil_wallet_address>; export NODE_OPERATOR_EMAIL=<your_email>; export SATURN_NETWORK=test
+  ```
+
+4. Run the playbook
   - Make sure to specify which hosts you want to provision in your inventory file.
   - Feel free to use labels (modify the `targets` var) to filter them or to deploy incrementally.
   - We're skipping the bootstrap play by default, as it deals with setting authorized keys on the target machine.
   - Note that you can define a specific `SATURN_HOME` by setting `volume_root` on your inventory file.
+
+  ```
+  ansible-playbook -i <path_to_your_inventory> --extra-vars targets=all --skip-tags=bootstrap playbooks/l1.yaml
+  ```
 
 ## Stopping a node
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Currently, this playbook runs on the following Linux distros:
   - CentOS
 
 These instructions are to be run in a machine with [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) >= 2.12 installed.
-  - This machine is known as your control node and it should not be the one to run your L1 node.
+This machine is known as your control node and it should not be the one to run your L1 node.
+
+Most commands are run as root and your ssh user should have root access on the target machine.
 
 1. Ensure your control node has ssh access to your target machine.
 

--- a/README.md
+++ b/README.md
@@ -105,26 +105,31 @@ This machine is known as your control node and it should not be the one to run y
 
 Most commands are run as root and your ssh user should have root access on the target machine.
 
-1. Ensure your control node has ssh access to your target machine.
+1. Clone this repository and `cd` into it.
+
+2. For target host connectivity, ssh keys are recommended and this playbook can help you with that.
+    1. Make sure you have configured `ansible_user` and `ansible_ssh_pass` for your target in your inventory file.
+    1. Setup an `authorized_keys` file with your public ssh keys in the cloned repository root.
+    2. Run `ansible-playbook -i <path_to_your_inventory> -l <host_label> --skip-tags=config,run playbooks/l1.yaml`
+
+3. Ensure your control node has ssh access to your target machine.
 
   ```
   ansible -vvv -i <path_to_your_inventory> <host_label> -m ping
   ```
 
-2. Clone this repository and `cd` into it.
-
-3. Replace the env var values where appropriate and export them.
+4. Replace the env var values where appropriate and export them.
   - If **Main network:** Set `SATURN_NETWORK` to `main`
-  - If moving either to the **main** or **test** networks change the `SATURN_NETWORK` value appropriately and run step 3 and 4.
+  - If moving either to the **main** or **test** networks change the `SATURN_NETWORK` value appropriately and run step 4 and 5.
 
   ```
   export FIL_WALLET_ADDRESS=<your_fil_wallet_address>; export NODE_OPERATOR_EMAIL=<your_email>; export SATURN_NETWORK=test
   ```
 
-4. Run the playbook
+5. Run the playbook
   - Make sure to specify which hosts you want to provision in your inventory file.
   - Feel free to use host labels to filter them or to deploy incrementally.
-  - We're skipping the bootstrap play by default, as it deals with setting authorized keys on the target machine.
+  - We're skipping the bootstrap play by default, as it deals with setting authorized ssh keys on the target machine. See 2 for more info.
   - Note that you can define a specific `SATURN_HOME` by setting `volume_root` on your inventory file.
 
   ```

--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ Most commands are run as root and your ssh user should have root access on the t
 
 4. Run the playbook
   - Make sure to specify which hosts you want to provision in your inventory file.
-  - Feel free to use labels (modify the `targets` var) to filter them or to deploy incrementally.
+  - Feel free to use host labels to filter them or to deploy incrementally.
   - We're skipping the bootstrap play by default, as it deals with setting authorized keys on the target machine.
   - Note that you can define a specific `SATURN_HOME` by setting `volume_root` on your inventory file.
 
   ```
-  ansible-playbook -i <path_to_your_inventory> --extra-vars targets=all --skip-tags=bootstrap playbooks/l1.yaml
+  ansible-playbook -i <path_to_your_inventory> -l <host_label> --skip-tags=bootstrap playbooks/l1.yaml
   ```
 
 ## Stopping a node

--- a/README.md
+++ b/README.md
@@ -89,20 +89,21 @@ on [Filecoin Slack](https://filecoinproject.slack.com/)!
 
 ## Running a node with Ansible
 
-Notes:
-- these instructions are to be run in a machine with [Ansible](https://docs.ansible.com/ansible/latest/index.html) installed.
-- This machine should not be your L1 node target deployment machine.
-- This machine should have ssh access to the target machine.
+This playbook is meant as a bare-bones approach to running an L1. These instructions are to be run in a machine with [Ansible](https://docs.ansible.com/ansible/latest/index.html) >= 2.12 installed.
+  - This machine should not be your L1 node target deployment machine.
+  - This machine should have ssh access to the said target machine.
 
-1. Make sure you have Ansible >= 2.12 installed.
+Currently, this playbook runs on the following Linux distros:
+  - Ubuntu
+  - CentOS
 
-2. Clone this repository and `cd` into it.
+1. Clone this repository and `cd` into it.
 
-3. Run `export FIL_WALLET_ADDRESS=<your_fil_wallet_address>; export NODE_OPERATOR_EMAIL=<your_email>; export SATURN_NETWORK=test`
+2. Run `export FIL_WALLET_ADDRESS=<your_fil_wallet_address>; export NODE_OPERATOR_EMAIL=<your_email>; export SATURN_NETWORK=test`
   - Replace the env var values where appropriate.
   - If **Main network:** Set `SATURN_NETWORK` to `main`
 
-4. Run `ansible-playbook -i <path_to_your_inventory> --extra-vars targets=all --skip-tags=bootstrap playbooks/l1.yaml`
+3. Run `ansible-playbook -i <path_to_your_inventory> --extra-vars targets=all --skip-tags=bootstrap playbooks/l1.yaml`
   - Make sure to specify which hosts you want to provision in your inventory file.
   - Feel free to use labels (modify the `targets` var) to filter them or to deploy incrementally.
   - We're skipping the bootstrap play by default, as it deals with setting authorized keys on the target machine.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ From [here](https://docs.ansible.com/ansible/latest/index.html#about-ansible):
 > "Ansible is an IT automation tool. It can configure systems, deploy software, and orchestrate more advanced IT tasks such as continuous deployments or zero downtime rolling updates."
 
 This playbook is meant as a bare-bones approach to running an L1. It simply automates running the steps described [above](#running-a-node). A consequence of this is that when run this playbook will restart a crashed L1 node docker container.
+
 Note: this does not cover server hardening and you should do your own research to ensure your server follows security best practices.
+If you want to cover server hardening, monitoring and logs check out https://github.com/hyphacoop/ansible-saturn-l1
 
 Currently, this playbook runs on the following Linux distros:
   - Ubuntu

--- a/README.md
+++ b/README.md
@@ -108,11 +108,14 @@ Most commands are run as root and your ssh user should have root access on the t
 1. Clone this repository and `cd` into it.
 
 2. For target host connectivity, ssh keys are recommended and this playbook can help you with that.
-    1. Make sure you have configured `ansible_user` and `ansible_ssh_pass` for your target in your inventory file.
+
+    Note: Using the playbook for this is completely optional.
+    1. Make sure you have configured `ansible_user` and `ansible_ssh_pass` for your target host in your inventory file. See more [here](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#adding-variables-to-inventory).
     1. Setup an `authorized_keys` file with your public ssh keys in the cloned repository root.
     2. Run `ansible-playbook -i <path_to_your_inventory> -l <host_label> --skip-tags=config,run playbooks/l1.yaml`
 
-3. Ensure your control node has ssh access to your target machine.
+3. Ensure your control node has ssh access to your target machine(s).
+  - Make sure to specify which hosts you want to provision in your inventory file.
 
   ```
   ansible -vvv -i <path_to_your_inventory> <host_label> -m ping
@@ -121,16 +124,15 @@ Most commands are run as root and your ssh user should have root access on the t
 4. Replace the env var values where appropriate and export them.
   - If **Main network:** Set `SATURN_NETWORK` to `main`
   - If you are switching networks check [Switching networks](#switching-networks) and rerun step 4 and 5.
+  - You can define a host-specific `SATURN_HOME` by setting a `saturn_root` variable for that host on your inventory file. See more [here](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#adding-variables-to-inventory).
 
   ```
   export FIL_WALLET_ADDRESS=<your_fil_wallet_address>; export NODE_OPERATOR_EMAIL=<your_email>; export SATURN_NETWORK=test
   ```
 
 5. Run the playbook
-  - Make sure to specify which hosts you want to provision in your inventory file.
   - Feel free to use host labels to filter them or to deploy incrementally.
   - We're skipping the bootstrap play by default, as it deals with setting authorized ssh keys on the target machine. See 2 for more info.
-  - Note that you can define a specific `SATURN_HOME` by setting `volume_root` on your inventory file.
 
   ```
   ansible-playbook -i <path_to_your_inventory> -l <host_label> --skip-tags=bootstrap playbooks/l1.yaml
@@ -163,14 +165,14 @@ If you are switching networks, follow these steps:
 
 ### Build
 
-Build the docker image with 
+Build the docker image with
 ```bash
 ./node build
 ```
 
 ### Run
 
-Run the docker container with 
+Run the docker container with
 ```bash
 ./node run
 ```
@@ -208,7 +210,7 @@ git commit -m "my commit message [skip ci]"
 
 #### Shim
 
-`shim/` contains the necessary code to fetch CIDs and CAR files for nginx to cache 
+`shim/` contains the necessary code to fetch CIDs and CAR files for nginx to cache
 
 
 ## License

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -91,7 +91,7 @@
   vars:
     # this wasn't consistent between runs, so we need to store it
     homedir: "{{ ansible_env.HOME }}"
-    saturn_home: "{{ volume_root if volume_root is defined else homedir }}"
+    saturn_home: "{{ saturn_root if saturn_root is defined else homedir }}"
     env_vars:
       SATURN_NETWORK: "{{ lookup('ansible.builtin.env', 'SATURN_NETWORK', default='test') }}"
       FIL_WALLET_ADDRESS: "{{ lookup('ansible.builtin.env', 'FIL_WALLET_ADDRESS', default=undef()) }}"

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -31,9 +31,11 @@
     packages:
       docker:
         CentOS: docker-ce
+        Debian: docker.io
         Ubuntu: docker.io
       pip:
         CentOS: python3-pip.noarch
+        Debian: python3-pip
         Ubuntu: python3-pip
   tasks:
   - name: Add docker repository

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -26,6 +26,7 @@
       key: "{{ lookup('file', '../authorized_keys') }}"
 
 - name: Configure playbook
+  tags: config
   hosts: all
   gather_facts: true
   vars:
@@ -85,6 +86,7 @@
       state: started
 
 - name: Run playbook
+  tags: run
   hosts: all
   vars:
     # this wasn't consistent between runs, so we need to store it

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Bootstrap playbook
   tags: bootstrap
-  hosts: "{{ targets }}"
+  hosts: all
   # https://stackoverflow.com/questions/32297456/how-to-ignore-ansible-ssh-authenticity-checking/54735937#54735937
   # Don't gather facts automatically because that will trigger
   # a connection, which needs to check the remote host key
@@ -24,8 +24,9 @@
       user: "{{ ansible_user }}"
       state: present
       key: "{{ lookup('file', '../authorized_keys') }}"
+
 - name: Configure playbook
-  hosts: "{{ targets }}"
+  hosts: all
   gather_facts: true
   vars:
     packages:
@@ -76,8 +77,9 @@
       name: docker
       enabled: true
       state: started
+
 - name: Run playbook
-  hosts: "{{ targets }}"
+  hosts: all
   vars:
     params:
       SATURN_NETWORK: "{{ lookup('ansible.builtin.env', 'SATURN_NETWORK', default='test') }}"


### PR DESCRIPTION
Following the feedback we got from Ben (🌅) :

- Added Ansible motivation
- Simplified using host labels with Ansible
- Documented switching networks through Ansible
- Mentioned having root access on the target machine
- Added a step to check ansible connectivity
- Documented running Ansible on Debian
- Clarified the Linux distros where the playbook works
- Explained how to setup ssh keys with the Ansible playbook
- Explained how to configure a host-specific `saturn_root`