### PR TITLE
Make 0-RTT explicit to the backend

### DIFF
--- a/container/nginx/conf.d/register.conf
+++ b/container/nginx/conf.d/register.conf
@@ -7,4 +7,6 @@ location = /register-check {
     proxy_set_header        X-Real-IP       $remote_addr;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        Connection      "";
+    # keep this in mind: https://blog.trailofbits.com/2019/03/25/what-application-developers-need-to-know-about-tls-early-data-0rtt/
+    proxy_set_header        Early-Data      $ssl_early_data;
 }

--- a/container/nginx/conf.d/shared.conf
+++ b/container/nginx/conf.d/shared.conf
@@ -44,6 +44,8 @@ location / {
     proxy_set_header        X-If-None-Match     $http_if_none_match;
     proxy_set_header        Connection          "";
     proxy_set_header        Saturn-Transfer-Id  $request_id;
+    # keep this in mind: https://blog.trailofbits.com/2019/03/25/what-application-developers-need-to-know-about-tls-early-data-0rtt/
+    proxy_set_header        Early-Data          $ssl_early_data;
 
     proxy_cache                 my_cache;
     proxy_cache_key             $uri$format_final$arg_filename$arg_download$param_go_get$http_if_none_match;


### PR DESCRIPTION
tl;dr: TlS 1.3 0-RTT leaves applications vulnerable to replay attacks. There are also issues with forward secrecy, but there is a little we can do there.

One way to counter this is to explicitly signal one's backend that early data is being sent. This way, that backend can decide to drop a given request for non-idempotent operations.

I don't think this is an actual risk since, currently, we're only distributing static content.
This won't matter for a typical `curl https://strn.pl/ipfs/QmQ2r6iMNpky5f1m4cnm3Yqw8VSvjuKpTcK1X7dBR1LkJF/cat.gif`.

It's something important to keep in mind however. More info [here](https://blog.trailofbits.com/2019/03/25/what-application-developers-need-to-know-about-tls-early-data-0rtt/).