### PR TITLE
Fix reported CPU count

### DIFF
--- a/container/shim/start.sh
+++ b/container/shim/start.sh
@@ -9,7 +9,7 @@ if [ -n "$host_resolvers" ]; then
 fi
 
 echo "$(date -u) [container] booting"
-echo "$(date -u) [container] CPUs: $(nproc)"
+echo "$(date -u) [container] CPUs: $(nproc --all)"
 echo "$(date -u) [container] Memory: $(awk '(NR<4)' /proc/meminfo | tr -d '  ' | tr '\n' ' ')"
 echo "$(date -u) [container] Disk: $(df -h /usr/src/app/shared | awk '(NR>1)')"
 [ -f /sys/block/sda/queue/rotational ] && echo "$(date -u) [container] SDD: $([ "$(cat /sys/block/sda/queue/rotational)" == "0" ] && echo 'true' || echo 'false')"

--- a/run.sh
+++ b/run.sh
@@ -9,9 +9,9 @@ echo "Running Saturn $SATURN_NETWORK network L1 Node on $SATURN_HOME"
 sudo docker rm -f saturn-node || true
 sudo docker run --name saturn-node -it -d \
   --restart=unless-stopped \
-  -v $SATURN_HOME/shared:/usr/src/app/shared \
-  -e FIL_WALLET_ADDRESS=$FIL_WALLET_ADDRESS \
-  -e NODE_OPERATOR_EMAIL=$NODE_OPERATOR_EMAIL \
+  -v "$SATURN_HOME/shared:/usr/src/app/shared" \
+  -e "FIL_WALLET_ADDRESS=$FIL_WALLET_ADDRESS" \
+  -e "NODE_OPERATOR_EMAIL=$NODE_OPERATOR_EMAIL" \
   --network host \
   --ulimit nofile=1000000 \
   ghcr.io/filecoin-saturn/l1-node:$SATURN_NETWORK

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -5,14 +5,14 @@
 : "${IPFS_GATEWAY_ORIGIN:=https://ipfs.io}"
 : "${ORCHESTRATOR_REGISTRATION:=true}"
 
-echo $(date -u) "[host] Running Saturn node dev"
+echo "$(date -u) [host] Running Saturn node dev"
 
 # Start the docker image
 docker run --name saturn-node -it --rm \
-          -v $(pwd)/shared:/usr/src/app/shared \
-          -e FIL_WALLET_ADDRESS=$FIL_WALLET_ADDRESS \
-          -e NODE_OPERATOR_EMAIL=$NODE_OPERATOR_EMAIL \
-          -e IPFS_GATEWAY_ORIGIN=$IPFS_GATEWAY_ORIGIN \
-          -e ORCHESTRATOR_REGISTRATION=$ORCHESTRATOR_REGISTRATION \
+          -v "$(pwd)/shared:/usr/src/app/shared" \
+          -e "FIL_WALLET_ADDRESS=$FIL_WALLET_ADDRESS" \
+          -e "NODE_OPERATOR_EMAIL=$NODE_OPERATOR_EMAIL" \
+          -e "IPFS_GATEWAY_ORIGIN=$IPFS_GATEWAY_ORIGIN" \
+          -e "ORCHESTRATOR_REGISTRATION=$ORCHESTRATOR_REGISTRATION" \
           -p 443:443 -p 80:80 \
           saturn-node


### PR DESCRIPTION
When running `ncpu` to report CPU count one should keep in mind it distinguishes between the CPUs available to the current process and the overall number of CPUs as described [here](https://unix.stackexchange.com/questions/427705/why-nproc-show-less-than-nproc-all).

I made it so reports all installed processors.