### PR TITLE
Do not restart the container when registration fails

### DIFF
--- a/container/shim/bin/shim.js
+++ b/container/shim/bin/shim.js
@@ -30,7 +30,8 @@ setTimeout(async function () {
   if (ORCHESTRATOR_REGISTRATION) {
     await register(true).catch(err => {
       debug(`Failed to register ${err.name} ${err.message}`)
-      process.exit(1)
+      // we don't try again if we fail the initial registration
+      process.exit(0)
     })
   }
 

--- a/container/shim/src/modules/registration.js
+++ b/container/shim/src/modules/registration.js
@@ -82,10 +82,11 @@ export async function register (initial) {
 
       debug('Success, restarting container...')
 
-      process.exit()
+      process.exit(1)
     } catch (err) {
       debug(`Failed initial registration: ${err.name} ${err.message}`)
-      process.exit(1)
+      // we don't restart if we failed the initial registration
+      process.exit(0)
     }
   } else {
     if (initial) {
@@ -106,7 +107,8 @@ export async function register (initial) {
 
       if (!valid) {
         await getNewTLSCert(registerOptions)
-        process.exit()
+        // we get the new cert and restart
+        process.exit(1)
       }
     }
 
@@ -131,7 +133,8 @@ export async function register (initial) {
     } catch (err) {
       debug('Failed re-registration %s', err.message)
       if (initial) {
-        process.exit(1)
+        // we don't try again if we fail the initial registration
+        process.exit(0)
       }
     }
   }

--- a/container/shim/src/utils/trap.js
+++ b/container/shim/src/utils/trap.js
@@ -7,7 +7,7 @@ const shutdownServer = (server) => () => {
   debug('Shutting down server')
   server.close(() => {
     debug('Server closed')
-    process.exit()
+    process.exit(0)
   })
 }
 

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ set -ex
 echo "Running Saturn $SATURN_NETWORK network L1 Node on $SATURN_HOME"
 sudo docker rm -f saturn-node || true
 sudo docker run --name saturn-node -it -d \
-  --restart=unless-stopped \
+  --restart=on-failure \
   -v "$SATURN_HOME/shared:/usr/src/app/shared" \
   -e "FIL_WALLET_ADDRESS=$FIL_WALLET_ADDRESS" \
   -e "NODE_OPERATOR_EMAIL=$NODE_OPERATOR_EMAIL" \

--- a/update.sh
+++ b/update.sh
@@ -44,7 +44,7 @@ if [[ $out != *"up to date"* ]]; then
   sudo docker stop saturn-node || true
   sudo docker rm -f saturn-node || true
   sudo docker run --name saturn-node -it -d \
-    --restart=unless-stopped \
+    --restart=on-failure \
     -v "$SATURN_HOME/shared:/usr/src/app/shared" \
     -e "FIL_WALLET_ADDRESS=$FIL_WALLET_ADDRESS" \
     -e "NODE_OPERATOR_EMAIL=$NODE_OPERATOR_EMAIL" \

--- a/update.sh
+++ b/update.sh
@@ -11,9 +11,9 @@ fi
 
 target=$SATURN_HOME/update.sh
 
-echo -n $(date -u) "Checking for auto-update script ($target) updates... "
+echo -n "$(date -u) Checking for auto-update script ($target) updates... "
 
-if wget -O "$target.tmp" -T 10 -t 3 "https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/update.sh" && [[ -s "$target.tmp" ]] && [ $(stat -c %s "$target.tmp") -ne $(stat -c %s "$target") ]
+if wget -O "$target.tmp" -T 10 -t 3 "https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/update.sh" && [[ -s "$target.tmp" ]] && [ "$(stat -c %s "$target.tmp")" -ne "$(stat -c %s "$target")" ]
 then
   mv -f "$target.tmp" "$target"
   chmod +x "$target"
@@ -24,18 +24,18 @@ else
   rm -f "$target.tmp"
 fi
 
-echo -n $(date -u) "Checking for Saturn $SATURN_NETWORK network L1 node updates... "
+echo -n "$(date -u) Checking for Saturn $SATURN_NETWORK network L1 node updates... "
 
 out=$(sudo docker pull ghcr.io/filecoin-saturn/l1-node:$SATURN_NETWORK)
 
 if [[ $out != *"up to date"* ]]; then
-  echo $(date -u) "New Saturn $SATURN_NETWORK network L1 node version found!"
+  echo "$(date -u) New Saturn $SATURN_NETWORK network L1 node version found!"
 
-  random_sleep=$[ ( $RANDOM % 3600 ) ]
-  echo $(date -u) "Waiting for $random_sleep seconds..."
-  sleep $random_sleep
+  random_sleep="$(( RANDOM % 3600 ))"
+  echo "$(date -u) Waiting for $random_sleep seconds..."
+  sleep "$random_sleep"
 
-  echo -n $(date -u) "Draining $SATURN_NETWORK network L1 node... "
+  echo -n "$(date -u) Draining $SATURN_NETWORK network L1 node... "
   sudo docker kill --signal=SIGTERM saturn-node >> /dev/null
   sleep 600
   echo "restarting...."
@@ -45,9 +45,9 @@ if [[ $out != *"up to date"* ]]; then
   sudo docker rm -f saturn-node || true
   sudo docker run --name saturn-node -it -d \
     --restart=unless-stopped \
-    -v $SATURN_HOME/shared:/usr/src/app/shared \
-    -e FIL_WALLET_ADDRESS=$FIL_WALLET_ADDRESS \
-    -e NODE_OPERATOR_EMAIL=$NODE_OPERATOR_EMAIL \
+    -v "$SATURN_HOME/shared:/usr/src/app/shared" \
+    -e "FIL_WALLET_ADDRESS=$FIL_WALLET_ADDRESS" \
+    -e "NODE_OPERATOR_EMAIL=$NODE_OPERATOR_EMAIL" \
     --network host \
     --ulimit nofile=1000000 \
     ghcr.io/filecoin-saturn/l1-node:$SATURN_NETWORK


### PR DESCRIPTION
The loop of registration attempts was leading to situations where speedtesting kept being run and that was saturating the network.
This approach will ensure we don't enter reboot loops.

To do this the changed the container restart policy to `on-failure`. This state is only intentionally triggered when getting a new SSL cert or when a registration besides the first one fails.