### PR TITLE
Flush nginx logs periodically

### DIFF
--- a/container/nginx/conf.d/shared.conf
+++ b/container/nginx/conf.d/shared.conf
@@ -1,4 +1,4 @@
-access_log  /var/log/nginx/node-access.log node buffer=256k flush=8m;
+access_log  /var/log/nginx/node-access.log node buffer=256k flush=1m;
 
 limit_req   zone=one burst=200 nodelay;
 

--- a/container/nginx/conf.d/shared.conf
+++ b/container/nginx/conf.d/shared.conf
@@ -1,4 +1,4 @@
-access_log  /var/log/nginx/node-access.log node buffer=256k;
+access_log  /var/log/nginx/node-access.log node buffer=256k flush=8m;
 
 limit_req   zone=one burst=200 nodelay;
 


### PR DESCRIPTION
Following https://github.com/filecoin-saturn/L1-node/issues/99, it should make sense to flush logs periodically.

This way, servers experiencing less traffic can ensure their logs are correctly persisted within a given time window.

A log line is generated per request. A log line should be about 450 bytes in size. Taking into account we're buffering 256k lines, this roughly means logs will be persisted every 569 requests (`256KB/450B`).

We want to flush as little as possible in order to avoid unneeded IO. So we need to maximize that value while making sure it's not too big for the nodes with less traffic to risk losing their logs.

Given that on average each node should be currently getting about 0.55 req/s, it will take about `569/0.55/60 ~= 17` minutes to fill the buffer.

That being said, 8m is around half-way this average time and, assuming a uniform request distribution over time, it seems like a reasonable enough threshold for the trade-off between persisting logs and frequent IO.

Lmk if if this makes sense!