### PR TITLE
docs: Fix broken link to FAQ in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ If you want to switch your node from Saturn's test network (aka `test`) to Satur
 
 ## Node operator guide
 
-For answers to common questions about operating a node, see the L1 node [docs/faq.md](FAQ) page.
+For answers to common questions about operating a node, see the L1 node [FAQ](docs/faq.md) page.
 
 ### Obtaining a Filecoin wallet address
 


### PR DESCRIPTION
The link name and target were inverted in the markdown by mistake.

Signed-off-by: Michael Vorburger ⛑️ <mike@vorburger.ch>