### PR TITLE
Load Bad Bits on container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,9 @@ RUN npm ci --production --ignore-scripts
 # copy the generated modules and all other files to the container
 COPY container/shim ./
 COPY container/nginx /etc/nginx/
-RUN rm /etc/nginx/conf.d/default.conf
+# Load CIDs ban lists
+RUN rm /etc/nginx/conf.d/default.conf \
+  && curl -s https://badbits.dwebops.pub/denylist.json | jq '.[].anchor' | xargs -I{} echo "location ~ \"{}\" { return 410; }" >> /etc/nginx/denylist.conf
 
 ARG RUN_NUMBER="9999"
 ARG GIT_COMMIT_HASH="dev"


### PR DESCRIPTION
This adds about `26632-69/3=26609` news CIDs to ban.

Approach
- `time curl -s https://badbits.dwebops.pub/denylist.json | jq '.[].anchor' | xargs -I{} echo "location ~ \"{}\" { return 410; }" >> /etc/nginx/denylist.conf`
  - this took about 45s on my machine, so we probably shouldn't do it on every boot to keep results fresh, but per build
  - if we release often enough we won't miss out too much on updates
- modified the Dockerfile to handle this