### PR TITLE
Fix log parser when URL has no query params

### DIFF
--- a/container/nginx/nginx.conf
+++ b/container/nginx/nginx.conf
@@ -33,7 +33,7 @@ http {
 
     reset_timedout_connection   on;
 
-    log_format node 'url=$scheme://$host$uri$is_args$args&&ua=$http_user_agent&&rid=$request_id'
+    log_format node 'url=$scheme://$host$uri&&args=$args&&ua=$http_user_agent&&rid=$request_id'
                     '&&s=$status&&b=$bytes_sent&&range=$http_range&&lt=$time_iso8601'
                     '&&rt=$request_time&&addr=$remote_addr&&ff=$http_x_forwarded_for'
                     '&&ref=$http_referer&&uct=$upstream_connect_time&&uht=$upstream_header_time'

--- a/container/shim/src/modules/log_ingestor.js
+++ b/container/shim/src/modules/log_ingestor.js
@@ -22,6 +22,7 @@ const NGINX_LOG_KEYS_MAP = {
   ucs: 'cacheHit',
   url: 'url'
 }
+const NGINX_NULL_VALUE = '-'
 const IPFS_PREFIX = '/ipfs/'
 const IPNS_PREFIX = '/ipns/'
 
@@ -86,11 +87,16 @@ async function parseLogs () {
         return Object.assign(varsAgg, { [NGINX_LOG_KEYS_MAP[name] || name]: parsedValue })
       }, {})
 
+      let { url, args } = vars
+      if (args !== NGINX_NULL_VALUE) {
+        url += `?${args}`
+      }
       let urlObj
 
       try {
-        urlObj = new URL(vars.url)
+        urlObj = new URL(url)
       } catch (err) {
+        debug(`Invalid URL: ${url}`)
         continue
       }
 
@@ -104,7 +110,7 @@ async function parseLogs () {
       const {
         clientAddress, numBytesSent, requestId, localTime, status,
         requestDuration, range, cacheHit, referrer, userAgent, http3,
-        httpProtocol, url
+        httpProtocol
       } = vars
 
       const cid = urlObj.pathname.split('/')[2]


### PR DESCRIPTION
I noticed the log file had weird URLs from the IPFS GW, they always ended with a hypen.

`https://bafybeignrwofccgre36alqmu7iwbikk5fxkbdmmjgwpvkurn7zqjyqg3ju.ipfs.dweb.link/-`

Reason being, if the request URL has no query params, then the nginx `$args`  value is `-`, not an empty string like I had assumed. I put the `$args` value into a separate log field to make log parsing easier. 

@DiegoRBaquero @joaosa 