### PR TITLE
Make start.sh abort and fail if one of its steps failed

### DIFF
--- a/container/shim/start.sh
+++ b/container/shim/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 # patch DNS to use the ones the host passed to docker
 # we grab the top two, so we don't potentially load balance over a ton of resolvers

--- a/container/shim/start.sh
+++ b/container/shim/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -eou pipefail
 
 # patch DNS to use the ones the host passed to docker
 # we grab the top two, so we don't potentially load balance over a ton of resolvers


### PR DESCRIPTION
This seems like a good idea, and could reduce confusion?

One example, among many different possible failures obviously, is what I ran into in #115: `nginx` failed to start, but the shim ran anyway. That's confusing, and it's probably safer to "fail fast" and abort on an `emerg` from Nginx, or any similar launch failures.

Please note that I HAVE NOT TESTED THIS 😈 at all... Does this project run integration tests on PRs?

Would you need me to rebuild and run with this to make sure it's fine? Or can you test it?
