### PR TITLE
Allow custom HTTP & HTTPS port in run.sh

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,6 +4,8 @@
 : "${NODE_OPERATOR_EMAIL:=dev@strn.pl}"
 : "${IPFS_GATEWAY_ORIGIN:=https://ipfs.io}"
 : "${ORCHESTRATOR_REGISTRATION:=true}"
+: "${HTTP_PORT:=80}"
+: "${HTTPS_PORT:=443}"
 
 echo "$(date -u) [host] Running Saturn node dev"
 
@@ -15,5 +17,5 @@ docker run --name saturn-node -it --rm \
           -e "IPFS_GATEWAY_ORIGIN=$IPFS_GATEWAY_ORIGIN" \
           -e "ORCHESTRATOR_REGISTRATION=$ORCHESTRATOR_REGISTRATION" \
           -e "SPEEDTEST_SERVER_CONFIG=$SPEEDTEST_SERVER_CONFIG" \
-          -p 443:443 -p 80:80 \
+          -p $HTTPS_PORT:443 -p $HTTP_PORT:80 \
           saturn-node


### PR DESCRIPTION
Because some people like developing where
"rootlessport cannot expose privileged port 80".
(One possible alternative with podman or rootless Docker, is
"'net.ipv4.ip_unprivileged_port_start=80' to /etc/sysctl.conf",
but adding this is simpler and permits running:

    HTTP_PORT=8080 HTTPS_PORT=8443 scripts/run.sh
