### PR TITLE
run.sh: Add :Z suffix to -v to develop with SELinux

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,7 +9,7 @@ echo "$(date -u) [host] Running Saturn node dev"
 
 # Start the docker image
 docker run --name saturn-node -it --rm \
-          -v "$(pwd)/shared:/usr/src/app/shared" \
+          -v "$(pwd)/shared:/usr/src/app/shared:Z" \
           -e "FIL_WALLET_ADDRESS=$FIL_WALLET_ADDRESS" \
           -e "NODE_OPERATOR_EMAIL=$NODE_OPERATOR_EMAIL" \
           -e "IPFS_GATEWAY_ORIGIN=$IPFS_GATEWAY_ORIGIN" \


### PR DESCRIPTION
https://docs.docker.com/engine/reference/commandline/run/#mount-volumes-from-container---volumes-from
documents that this enables runnings this script on developer
workstations which have SELinux enabled, such as Fedora.

Without this, it will fail to start due to:
mkdir: cannot create directory '/usr/src/app/shared/ssl': Permission denied

For Docker on hosts without SELinux, this option is just ignored.
