### PR TITLE
chore: Add .prettierrc.json for https://prettier.io

### DIFF
--- a/container/shim/.prettierrc.json
+++ b/container/shim/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "none"
+}


### PR DESCRIPTION
Would this be of interest & acceptable? See https://prettier.io for background.

Initial content based on what I "reversed engineered" to be the code conventions apparently used in this project.

Obviously absolutely no offense taken either of course if this is not something you want to use. (But in that case, would a [`.prettierignore`](https://prettier.io/docs/en/ignore.html) be an acceptable PR instead? That would prevent folks who have Prettier installed in their editors from messing up formatting when contributing.)

PS: https://prettier.io/docs/en/watching-files.html may also be fun, if you want that; or perhaps better ESLint (which you already use) integration with https://prettier.io/docs/en/related-projects.html.

