### PR TITLE
move nginx logs to mounted volume

### DIFF
--- a/.github/ISSUE_TEMPLATE/ip-geolocation-override.md
+++ b/.github/ISSUE_TEMPLATE/ip-geolocation-override.md
@@ -2,9 +2,8 @@
 name: IP geolocation override
 about: Template to request an IP geolocation override
 title: Geolocation fix
-labels: ''
-assignees: ''
-
+labels: ""
+assignees: ""
 ---
 
 IP:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ARG CONFIG="--prefix=/etc/nginx \
  --sbin-path=/usr/sbin/nginx \
  --modules-path=/usr/lib/nginx/modules \
  --conf-path=/etc/nginx/nginx.conf \
- --error-log-path=/var/log/nginx/error.log \
- --http-log-path=/var/log/nginx/node-access.log \
+ --error-log-path=/usr/src/app/shared/nginx_log/error.log \
+ --http-log-path=/usr/src/app/shared/nginx_log/node-access.log \
  --pid-path=/var/run/nginx.pid \
  --lock-path=/var/run/nginx.lock \
  --user=nginx --group=nginx \

--- a/container/nginx/conf.d/shared.conf
+++ b/container/nginx/conf.d/shared.conf
@@ -1,4 +1,4 @@
-access_log  /var/log/nginx/node-access.log node buffer=256k flush=1m;
+access_log  /usr/src/app/shared/nginx_log/node-access.log node buffer=256k flush=1m;
 
 limit_req   zone=one burst=200 nodelay;
 

--- a/container/nginx/nginx.conf
+++ b/container/nginx/nginx.conf
@@ -4,7 +4,7 @@ load_module /usr/lib/nginx/modules/ngx_http_brotli_static_module.so;
 user  nginx;
 worker_processes  auto;
 
-error_log  /var/log/nginx/error.log notice;
+error_log  /usr/src/app/shared/nginx_log/error.log notice;
 pid        /var/run/nginx.pid;
 
 events {
@@ -19,7 +19,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  /usr/src/app/shared/nginx_log/access.log  main;
 
     # == custom node directives ==
     aio                 on;

--- a/container/shim/src/modules/log_ingestor.js
+++ b/container/shim/src/modules/log_ingestor.js
@@ -52,7 +52,7 @@ let parseLogsTimer;
 let submitRetrievalsTimer;
 
 export async function initLogIngestor() {
-  if (fs.existsSync("/var/log/nginx/node-access.log")) {
+  if (fs.existsSync("/usr/src/app/shared/nginx_log/node-access.log")) {
     debug("Reading nginx log file");
     fh = await openFileHandle();
 
@@ -161,7 +161,7 @@ async function parseLogs() {
 }
 
 async function openFileHandle() {
-  return await fsPromises.open("/var/log/nginx/node-access.log", "r+");
+  return await fsPromises.open("/usr/src/app/shared/nginx_log/node-access.log", "r+");
 }
 
 export async function submitRetrievals() {

--- a/container/shim/start.sh
+++ b/container/shim/start.sh
@@ -18,6 +18,7 @@ echo "$(date -u) [container] Disk: $(df -h /usr/src/app/shared | awk '(NR>1)')"
 
 # Create if not exists
 mkdir -p /usr/src/app/shared/ssl
+mkdir -p /usr/src/app/shared/nginx_log
 
 L1_CONF_FILE=/etc/nginx/conf.d/L1.conf
 


### PR DESCRIPTION
- move nginx log from `/var/log/nginx` to mounted volume `/usr/src/app/shared/nginx_log`
- path consistent with nginx cache location which is `/usr/src/app/shared/nginx_cache`
- because currently nginx logs are not persisted when container is recreated we do not need to worry about past logs

_this is prerequisite for persisting nginx logs and network monitoring that will come in another pull request_