### PR TITLE
correct docker compose to docker-compose

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: 'arm64'
+          platforms: "arm64"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     labels:
       com.centurylinklabs.watchtower.scope: saturn
       com.centurylinklabs.watchtower.enable: "true"
-      com.centurylinklabs.watchtower.lifecycle.pre-update: "sleep $((RANDOM % 3600))"
+      com.centurylinklabs.watchtower.lifecycle.pre-update: "sleep $$((RANDOM % 3600))"
       com.centurylinklabs.watchtower.lifecycle.pre-update-timeout: 3600
     volumes:
       - ${SATURN_HOME:-$HOME}/shared:/usr/src/app/shared

--- a/update.sh
+++ b/update.sh
@@ -38,7 +38,7 @@ else
   fi
 
   echo "Testing compatibility with our Docker Compose workflow"
-  if ! sudo docker compose version;
+  if ! sudo docker-compose version;
   then
       echo "docker compose might not be supported by your setup, or you are still using an old docker-compose version";
       exit 1
@@ -51,16 +51,16 @@ else
   sleep "$random_sleep"
 
   echo "Pulling Saturn $SATURN_NETWORK network L1 node updates."
-  sudo -E docker compose -f "$compose_file" pull
+  sudo -E docker-compose -f "$compose_file" pull
 
   echo "Draining $SATURN_NETWORK network L1 node... "
   sudo docker stop --time 900 saturn-node || true
 
   echo "Restarting with docker compose now..."
   sudo docker rm -f saturn-node || true
-  sudo -E docker compose -f "$compose_file" pull
+  sudo -E docker-compose -f "$compose_file" pull
   
-  if ! sudo -E docker compose -f "$compose_file" up -d;
+  if ! sudo -E docker-compose -f "$compose_file" up -d;
   then
       echo "Error while launching the docker compose setup. Please try running 'docker compose up -d' yourself or open an issue on Github."
       exit 1

--- a/update.sh
+++ b/update.sh
@@ -17,33 +17,39 @@ echo "The auto-update script was deprecated to migrate to a docker compose setup
 echo "The run script was deprecated too. To start or stop your node use 'docker compose -f ${compose_file} up -d' or 'docker compose -f $compose_file down' respectively."
 
 if [ -f "$compose_file" ]; then
-    echo "We have migrated to a docker compose setup to reduce risks caused by these update and run scripts. You can delete these scripts and use the Docker Compose workflow now."
+    echo "We have migrated to a docker-compose setup to reduce risks caused by these update and run scripts. You can delete these scripts and use the Docker Compose workflow now."
 else 
   wget -O "$compose_file" -T 10 -t 3 "https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml"
   if [[ -s "$compose_file" ]];
   then
-    echo "Downloaded the docker compose file successfully!"
+    echo "Downloaded the docker-compose file successfully!"
   else
-    echo "Failed to download the docker compose file automagically. Please open a Github issue or migrate manually to the docker compose setup"
+    echo "Failed to download the docker-compose file automagically. Please open a Github issue or migrate manually to the docker-compose setup"
     exit 1
   fi
 
-  wget -O "$env_file" -T 10 -t 3 "https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/.env"
+  if [ ! -f "$env_file" ]];
+  then
+    echo FIL_WALLET_ADDRESS=\"$FIL_WALLET_ADDRESS\" > $env_file
+    echo NODE_OPERATOR_EMAIL=\"$NODE_OPERATOR_EMAIL\" >> $env_file
+    echo SATURN_NETWORK=\"$SATURN_NETWORK\" >> $env_file
+    echo SATURN_HOME=\"$SATURN_HOME\" >> $env_file
+  fi
   if [[ -s "$env_file" ]];
   then
-    echo "Downloaded the .env file successfully!"
+    echo "Downloaded the .env file migrated successfully!"
   else
-    echo "Failed to download the .env file automagically. Please open a Github issue or migrate manually to the docker compose setup"
+    echo "Failed to download the .env file automagically. Please open a Github issue or migrate manually to the docker-compose setup"
     exit 1
   fi
 
-  echo "Testing compatibility with our Docker Compose workflow"
+  echo "Testing compatibility with our Docker-Compose workflow"
   if ! sudo docker-compose version;
   then
-      echo "docker compose might not be supported by your setup, or you are still using an old docker-compose version";
+      echo "docker-compose might not be supported by your setup, or you are still using an old docker-compose version";
       exit 1
   fi
-  echo "You have docker compose, proceeding."
+  echo "You have docker-compose, proceeding."
   printf "If any of the following steps fail, please edit the .env file to include the expected values and try running the commands:\n\t'sudo docker stop --time 900 saturn-node && sudo docker compose -f %s up -d'." "$compose_file"
 
   random_sleep="$(( RANDOM % 2000 ))"
@@ -56,13 +62,13 @@ else
   echo "Draining $SATURN_NETWORK network L1 node... "
   sudo docker stop --time 900 saturn-node || true
 
-  echo "Restarting with docker compose now..."
+  echo "Restarting with docker-compose now..."
   sudo docker rm -f saturn-node || true
   sudo -E docker-compose -f "$compose_file" pull
   
   if ! sudo -E docker-compose -f "$compose_file" up -d;
   then
-      echo "Error while launching the docker compose setup. Please try running 'docker compose up -d' yourself or open an issue on Github."
+      echo "Error while launching the docker-compose setup. Please try running 'docker-compose up -d' yourself or open an issue on Github."
       exit 1
   fi
   echo "Updated to the latest version successfully! You can now delete the run.sh and update.sh scripts."

--- a/update.sh
+++ b/update.sh
@@ -28,7 +28,7 @@ else
     exit 1
   fi
 
-  if [ ! -f "$env_file" ]];
+  if [ ! -f "$env_file" ];
   then
     echo FIL_WALLET_ADDRESS=\"$FIL_WALLET_ADDRESS\" > $env_file
     echo NODE_OPERATOR_EMAIL=\"$NODE_OPERATOR_EMAIL\" >> $env_file


### PR DESCRIPTION
Update script is currently broken. This patch attempts to fix it.

There should also be a migration path for people that run docker to docker-compose


Fixes:
- `docker compose` should be `docker-compose`
- `docker-compose.yml`  requires escaped $ in watchtower line
- Corrected prettier yml due to CI complaining about it