### PR TITLE
resumable log ingestor

### DIFF
--- a/container/shim/package-lock.json
+++ b/container/shim/package-lock.json
@@ -22,6 +22,7 @@
         "multiformats": "^11.0.1",
         "node-fetch": "^3.3.0",
         "p-defer": "^4.0.0",
+        "p-limit": "^4.0.0",
         "p-timeout": "^6.1.0",
         "pretty-bytes": "^6.0.0",
         "stream-write": "^2.0.0",
@@ -2326,6 +2327,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-queue": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
@@ -2845,6 +2860,17 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-2.0.0.tgz",
       "integrity": "sha512-AsAqZfPAuWx7qB/0kyRDUEvoU3QKsHWzHU9smFlkaiprEpGfJ/NBbLze2Uq0rdkxCxkNM9uOLvz/KoNBCbZiLQ=="
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -4406,6 +4432,14 @@
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
       "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
     },
+    "p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "requires": {
+        "yocto-queue": "^1.0.0"
+      }
+    },
     "p-queue": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
@@ -4791,6 +4825,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-2.0.0.tgz",
       "integrity": "sha512-AsAqZfPAuWx7qB/0kyRDUEvoU3QKsHWzHU9smFlkaiprEpGfJ/NBbLze2Uq0rdkxCxkNM9uOLvz/KoNBCbZiLQ=="
+    },
+    "yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
     }
   }
 }

--- a/container/shim/package-lock.json
+++ b/container/shim/package-lock.json
@@ -16,6 +16,7 @@
         "debug": "^4.3.4",
         "express": "^4.18.2",
         "express-async-handler": "^1.2.0",
+        "fast-glob": "^3.2.12",
         "ipfs-unixfs-exporter": "^10.0.0",
         "logfmt": "^1.3.2",
         "mime-types": "^2.1.35",
@@ -811,6 +812,38 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1018,6 +1051,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/brorand": {
@@ -1394,6 +1438,29 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -1414,6 +1481,17 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/finalhandler": {
@@ -1532,6 +1610,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/hamt-sharding": {
@@ -1854,6 +1943,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -1864,6 +1972,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -2128,12 +2244,32 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -2391,6 +2527,17 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.0.0.tgz",
@@ -2460,6 +2607,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2510,6 +2676,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -2729,6 +2926,17 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -3332,6 +3540,29 @@
         }
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -3501,6 +3732,14 @@
         "iso-url": "^1.1.5",
         "json-text-sequence": "~0.3.0",
         "readable-stream": "^3.6.0"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
       }
     },
     "brorand": {
@@ -3794,6 +4033,26 @@
       "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
       "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
     },
+    "fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
+    "fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
     "fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -3801,6 +4060,14 @@
       "requires": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
       }
     },
     "finalhandler": {
@@ -3891,6 +4158,14 @@
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "hamt-sharding": {
@@ -4115,11 +4390,29 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
     "is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
       "dev": true
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-number-object": {
       "version": "1.0.7",
@@ -4305,10 +4598,24 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
     },
     "mime": {
       "version": "1.6.0",
@@ -4471,6 +4778,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
     "pretty-bytes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.0.0.tgz",
@@ -4518,6 +4830,11 @@
         "side-channel": "^1.0.4"
       }
     },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4553,6 +4870,19 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "functions-have-names": "^1.2.2"
+      }
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "safe-buffer": {
@@ -4730,6 +5060,14 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
     },
     "toidentifier": {
       "version": "1.0.1",

--- a/container/shim/package.json
+++ b/container/shim/package.json
@@ -24,6 +24,7 @@
     "multiformats": "^11.0.1",
     "node-fetch": "^3.3.0",
     "p-defer": "^4.0.0",
+    "p-limit": "^4.0.0",
     "p-timeout": "^6.1.0",
     "pretty-bytes": "^6.0.0",
     "stream-write": "^2.0.0",

--- a/container/shim/package.json
+++ b/container/shim/package.json
@@ -18,6 +18,7 @@
     "debug": "^4.3.4",
     "express": "^4.18.2",
     "express-async-handler": "^1.2.0",
+    "fast-glob": "^3.2.12",
     "ipfs-unixfs-exporter": "^10.0.0",
     "logfmt": "^1.3.2",
     "mime-types": "^2.1.35",

--- a/container/shim/src/bin/shim.js
+++ b/container/shim/src/bin/shim.js
@@ -14,7 +14,7 @@ import {
 } from "../config.js";
 import { trapServer } from "../utils/trap.js";
 import { debug } from "../utils/logging.js";
-import { submitRetrievals, initLogIngestor } from "../modules/log_ingestor.js";
+import startLogIngestor from "../modules/log_ingestor.js";
 import { refreshLocalNodes } from "../modules/local_nodes.js";
 
 debug("Saturn L1 Node");
@@ -43,8 +43,9 @@ setTimeout(async function () {
     });
   }
 
-  // Start log ingestor
-  await initLogIngestor();
+  // run log ingestor process in background (starts immediately and keeps running periodically)
+  startLogIngestor();
+
   refreshLocalNodes();
 }, 500);
 
@@ -59,7 +60,7 @@ trapServer(server);
 
 async function shutdown() {
   try {
-    await Promise.allSettled([submitRetrievals(), ORCHESTRATOR_REGISTRATION ? deregister() : Promise.resolve()]);
+    await Promise.allSettled([startLogIngestor(), ORCHESTRATOR_REGISTRATION ? deregister() : Promise.resolve()]);
   } catch (err) {
     debug(`Failed during shutdown: ${err.name} ${err.message}`);
   } finally {

--- a/container/shim/src/modules/log_ingestor.js
+++ b/container/shim/src/modules/log_ingestor.js
@@ -195,5 +195,8 @@ async function executeLogIngestor() {
   }
 
   // ... otherwise, wait up to 60 seconds from the start of this function before running again
-  executeLogIngestor.timeout = setTimeout(startLogIngestor, Math.max(0, 60_000 - (Date.now() - startTime)));
+  executeLogIngestor.timeout = setTimeout(() => {
+    // restart execution of ingestor again only if there are no pending executions already in the queue
+    if (limitConcurrency.pendingCount === 0) startLogIngestor();
+  }, Math.max(0, 60_000 - (Date.now() - startTime)));
 }

--- a/container/shim/src/modules/log_ingestor.js
+++ b/container/shim/src/modules/log_ingestor.js
@@ -1,8 +1,8 @@
-import fs from "node:fs";
-import fsPromises from "node:fs/promises";
+import fs from "node:fs/promises";
 import fetch from "node-fetch";
 import prettyBytes from "pretty-bytes";
 import logfmt from "logfmt";
+import readlines from "../utils/readlines.js";
 
 import { FIL_WALLET_ADDRESS, LOG_INGESTOR_URL, nodeId, nodeToken, TESTING_CID } from "../config.js";
 import { debug as Debug } from "../utils/logging.js";
@@ -41,155 +41,150 @@ const NGINX_LOG_KEYS_MAP = {
     return isNaN(parsed) ? values.urt : parsed;
   },
 };
-const IPFS_PREFIX = "/ipfs/";
-const IPNS_PREFIX = "/ipns/";
 
-const ONE_GIGABYTE = 1073741823;
+const LOG_FILE = "/usr/src/app/shared/nginx_log/node-access.log";
 
-let pending = [];
-let fh, hasRead;
-let parseLogsTimer;
-let submitRetrievalsTimer;
+/**
+ * Check if a file is accessible with the given flags.
+ *
+ * @param {string} filename
+ * @param {number} flags - use fs.constants.R_OK, fs.constants.W_OK, etc.
+ * @returns {Promise<boolean>} true if the file is accessible, false otherwise
+ */
+async function isFileAccessible(filename, flags = fs.constants.R_OK) {
+  try {
+    await fs.access(filename, flags);
 
-export async function initLogIngestor() {
-  if (fs.existsSync("/usr/src/app/shared/nginx_log/node-access.log")) {
-    debug("Reading nginx log file");
-    fh = await openFileHandle();
+    return true;
+  } catch (error) {
+    debug(`Cannot access ${filename} (${flags}): ${error.message}`);
 
-    parseLogs();
-
-    submitRetrievals();
+    return false;
   }
 }
 
-async function parseLogs() {
-  clearTimeout(parseLogsTimer);
-  const stat = await fh.stat();
+function parseSingleLine(line) {
+  // parse the line into an object
+  const parsed = logfmt.parse(line);
 
-  if (stat.size >= ONE_GIGABYTE) {
-    // Got to big we can't read it into single string
-    // TODO: stream read it
-    await fh.truncate();
-  }
+  // use mapped keys and getters to extract the values we want
+  const vars = Object.entries(NGINX_LOG_KEYS_MAP).reduce((acc, [key, getter]) => {
+    acc[key] = getter(parsed);
+    return acc;
+  }, {});
 
-  const read = await fh.readFile();
+  const isIPFS = vars.url.pathname.startsWith("/ipfs/");
+  const isIPNS = vars.url.pathname.startsWith("/ipns/");
 
-  let valid = 0;
-  let hits = 0;
-  if (read.length > 0) {
-    hasRead = true;
-    const lines = read.toString().trim().split("\n");
+  // only submit logs for IPFS/IPNS requests
+  if (!isIPFS && !isIPNS) return null;
 
-    for (const line of lines) {
-      const parsed = logfmt.parse(line);
-      const vars = Object.entries(NGINX_LOG_KEYS_MAP).reduce((acc, [key, getter]) => {
-        acc[key] = getter(parsed);
-        return acc;
-      }, {});
-      let urlObj;
+  const cid = vars.url.pathname.split("/")[2];
 
-      try {
-        urlObj = new URL(vars.url);
-      } catch (err) {
-        debug(`Invalid URL: ${vars.url}`);
-        continue;
+  // do not submit logs for testing CID
+  if (cid === TESTING_CID) return null;
+
+  return {
+    cacheHit: vars.cacheHit,
+    clientAddress: vars.clientAddress,
+    localTime: vars.localTime,
+    numBytesSent: vars.numBytesSent,
+    range: vars.range,
+    referrer: vars.referrer,
+    requestDuration: vars.requestDuration,
+    requestId: vars.requestId,
+    userAgent: vars.userAgent,
+    httpStatusCode: vars.status,
+    // If/when "httpProtocol" eventually contains HTTP/3.0, then
+    // the "http3" key can be removed.
+    httpProtocol: vars.http3 || vars.httpProtocol,
+    url: vars.url,
+  };
+}
+
+/**
+ * Submits parsed bandwidth logs to the orchestrator.
+ *
+ * @param {Array} logs - array of parsed bandwidth logs
+ * @returns {Promise<void>} - resolves once the logs are successfully submitted to the orchestrator
+ */
+async function submitLogs(logs) {
+  // cache hit rate for this batch of retrievals
+  const cacheHits = logs.filter(({ cacheHit }) => cacheHit).length;
+  const cacheHitRate = cacheHits / logs.length;
+  const cacheHitRatePercent = Math.round(cacheHitRate * 100);
+
+  // total bytes sent to clients for this batch or retrievals
+  const totalBytesSent = logs.reduce((acc, { numBytesSent }) => acc + numBytesSent, 0);
+  const totalBytesSentPretty = prettyBytes(totalBytesSent);
+
+  debug(`Submitting ${logs.length} retrievals (${totalBytesSentPretty} with cache rate of ${cacheHitRatePercent}%)`);
+
+  const submitTime = Date.now();
+
+  await fetch(LOG_INGESTOR_URL, {
+    method: "POST",
+    body: JSON.stringify({ nodeId, filAddress: FIL_WALLET_ADDRESS, bandwidthLogs: logs }),
+    headers: { Authentication: nodeToken, "Content-Type": "application/json" },
+  });
+
+  debug(`Retrievals submitted succesfully to wallet ${FIL_WALLET_ADDRESS} in ${Date.now() - submitTime}ms`);
+}
+
+/**
+ * Runs the log ingestor function responsible for reading the nginx log file and submitting the logs to the orchestrator.
+ * It starts immediately once this function is called, calls itself recursively until the log file is read in full, and
+ * then sets a timeout to call itself again after at most 1 minute from the last time it was called. It keeps track of
+ * the last line read in the log file and only reads the lines after that line.
+ * This function can be called manually to force a log ingestor submission (e.g. when node is shutting down).
+ *
+ * @returns {Promise<void>} - resolves once the log ingestor finished current run and is scheduled to run again.
+ */
+export default async function startLogIngestor() {
+  // clear timeout timer if it exists (this is to prevent multiple timers from being set)
+  if (startLogIngestor.timeout) clearTimeout(startLogIngestor.timeout);
+
+  const startTime = Date.now();
+
+  if (await isFileAccessible(LOG_FILE)) {
+    // stream the log file and parse the lines
+    const read = await readlines(LOG_FILE);
+
+    if (read.lines.length) {
+      const logs = [];
+
+      for (let i = 0; i < read.lines.length; i++) {
+        // skip empty lines
+        if (read.lines[i] === "") continue;
+
+        // parse the line into an object
+        const parsed = parseSingleLine(read.lines[i]);
+
+        // add parsed log line if it is valid (only valid retrieval)
+        if (parsed) logs.push(parsed);
       }
 
-      const isIPFS = urlObj.pathname.startsWith(IPFS_PREFIX);
-      const isIPNS = urlObj.pathname.startsWith(IPNS_PREFIX);
+      // submit the logs to the log ingestor
+      if (logs.length) {
+        try {
+          // submit parsed logs to the orchestrator
+          await submitLogs(logs);
 
-      if (!isIPFS && !isIPNS) {
-        continue;
+          // mark the lines as read once they have been submitted successfully
+          // which persists new read bytes offset to the disk so it will not be read again
+          await read.confirmed();
+        } catch (error) {
+          debug(`Failed to submit ${logs.length} retrievals: ${error.name} ${error.message}`);
+        }
+      } else {
+        debug(`No retrievals to submit since ${new Date(startTime).toISOString()}`);
       }
-
-      const {
-        clientAddress,
-        numBytesSent,
-        requestId,
-        localTime,
-        status,
-        requestDuration,
-        range,
-        cacheHit,
-        referrer,
-        userAgent,
-        http3,
-        httpProtocol,
-        url,
-      } = vars;
-
-      const cid = urlObj.pathname.split("/")[2];
-
-      if (cid === TESTING_CID) continue;
-
-      pending.push({
-        cacheHit,
-        clientAddress,
-        localTime,
-        numBytesSent,
-        range,
-        referrer,
-        requestDuration,
-        requestId,
-        userAgent,
-        httpStatusCode: status,
-        // If/when "httpProtocol" eventually contains HTTP/3.0, then
-        // the "http3" key can be removed.
-        httpProtocol: http3 || httpProtocol,
-        url,
-      });
-
-      valid++;
-      if (cacheHit) hits++;
     }
-    if (valid > 0) {
-      debug(
-        `Parsed ${valid} valid retrievals in ${prettyBytes(read.length)} with hit rate of ${Number(
-          ((hits / valid) * 100).toFixed(2)
-        )}%`
-      );
-    }
-  } else {
-    if (hasRead) {
-      await fh.truncate();
-      await fh.close();
-      hasRead = false;
-      fh = await openFileHandle();
-    }
+
+    // run this function again immediately if there were more lines to read (read.eof is false)
+    if (read.eof === false) return startLogIngestor();
   }
-  parseLogsTimer = setTimeout(parseLogs, Math.max(10_000 - valid, 1000));
-}
 
-async function openFileHandle() {
-  return await fsPromises.open("/usr/src/app/shared/nginx_log/node-access.log", "r+");
-}
-
-export async function submitRetrievals() {
-  clearTimeout(submitRetrievalsTimer);
-  const length = pending.length;
-  if (length > 0) {
-    const body = {
-      nodeId,
-      filAddress: FIL_WALLET_ADDRESS,
-      bandwidthLogs: pending,
-    };
-    pending = [];
-    try {
-      debug(`Submitting ${length} pending retrievals`);
-      const startTime = Date.now();
-      await fetch(LOG_INGESTOR_URL, {
-        method: "POST",
-        body: JSON.stringify(body),
-        headers: {
-          Authentication: nodeToken,
-          "Content-Type": "application/json",
-        },
-      });
-      debug(`Submitted ${length} retrievals to wallet ${FIL_WALLET_ADDRESS} in ${Date.now() - startTime}ms`);
-    } catch (err) {
-      debug(`Failed to submit pending retrievals ${err.name} ${err.message}`);
-      pending = body.bandwidthLogs.concat(pending);
-    }
-  }
-  submitRetrievalsTimer = setTimeout(submitRetrievals, Math.max(60_000 - length, 10_000));
+  // ... otherwise, wait up to 60 seconds from the start of this function before running again
+  startLogIngestor.timeout = setTimeout(startLogIngestor, Math.max(0, 60_000 - (Date.now() - startTime)));
 }

--- a/container/shim/src/utils/readlines.js
+++ b/container/shim/src/utils/readlines.js
@@ -1,0 +1,151 @@
+import { open, stat } from "node:fs/promises";
+
+function offsetFilename(filename) {
+  return `${filename}.offsetfile`;
+}
+
+async function getFileContents(filename) {
+  const file = await open(filename, "r");
+
+  try {
+    return await file.readFile(); // await to ensure finally is called after file is read
+  } finally {
+    await file.close();
+  }
+}
+
+async function getResumableOffset(filename) {
+  try {
+    // get current file stat and read the offsetfile contents
+    const [currentStat, offsetfile] = await Promise.all([stat(filename), getFileContents(offsetFilename(filename))]);
+
+    // file is empty, reset the offset
+    if (offsetfile === "") {
+      return setResumableOffset(filename, 0, currentStat);
+    }
+
+    // offsetfile contains stringified JSON object with { offset [int], ino [int], size [int] }
+    const resumable = JSON.parse(offsetfile);
+
+    // if the file has been rotated, truncated or offset is corrupted, reset the offsetfile
+    const isFileRotated = resumable.ino !== currentStat.ino; // https://en.wikipedia.org/wiki/Inode
+    const isFileTruncated = resumable.size > currentStat.size || resumable.offset > currentStat.size;
+    const isOffsetCorrupted = isNaN(resumable.offset);
+
+    if (isFileRotated || isFileTruncated || isOffsetCorrupted) {
+      return setResumableOffset(filename, 0, currentStat);
+    }
+
+    return resumable.offset;
+  } catch (error) {
+    // file does not exist, create it
+    if (error.code === "ENOENT") {
+      return setResumableOffset(filename, 0);
+    }
+
+    // re-throw error if it's not ENOENT
+    throw error;
+  }
+}
+
+async function setResumableOffset(filename, offset, currentStat) {
+  const { ino, size } = currentStat ?? (await stat(filename));
+  const offsetfile = await open(offsetFilename(filename), "w");
+
+  try {
+    // store inode and file size alongside offset to detect file rotation
+    await offsetfile.writeFile(JSON.stringify({ ino, size, offset }));
+  } finally {
+    await offsetfile.close();
+  }
+
+  return offset;
+}
+
+/**
+ * Read lines from a file and return them as an array.
+ * This function will resume reading from the last offset if no offset is provided.
+ * The returned promise will resolve when the readSize is reached or the end of the file is reached.
+ * The returned promise will reject if the file cannot be opened or read.
+ * The returned promise will resolve with an object containing:
+ * - lines: an array of lines read from the file
+ * - offset: the byte offset of the last line read
+ * - eof: true if the end of the file was reached
+ * - confirmed: a function that confirms that the lines were processed and the offset can be updated
+ *
+ * @param {string} filename - file name to read from
+ * @param {number} offsetBytes - byte offset to start reading from (default: resume from last offset)
+ * @param {number} readSize - max number of bytes to read at a time (default 10MB)
+ * @returns {Promise<{lines: string[], offset: number, eof: boolean, confirmed: () => Promise<void>}>
+ */
+export default async function readlines(filename, offsetBytes = null, readSize = 10 * 1024 * 1024) {
+  // if no offset is provided, get the last offset from the offsetfile
+  if (offsetBytes === null) offsetBytes = await getResumableOffset(filename);
+
+  // open the file for reacding and create a read stream starting at the given offset
+  const file = await open(filename, "r");
+  const stream = file.createReadStream({ encoding: "utf8", start: offsetBytes });
+
+  // setting read size to less than the stream's readableHighWaterMark will cause the stream to end
+  // after every chunk read (chunk size set in readableHighWaterMark) which will be highly inefficient
+  // so we throw an error if the readSize is less than the readableHighWaterMark
+  if (readSize < stream.readableHighWaterMark) {
+    throw new Error(`readSize must be greater than readableHighWaterMark (${stream.readableHighWaterMark} bytes)`);
+  }
+
+  return new Promise((resolve, reject) => {
+    const lines = [];
+    let adjustBytes = 0;
+
+    // This event is emitted for every chunk read (chunk size set in readableHighWaterMark)
+    // until the stream is closed once we reach end of file or readSize (whichever comes first).
+    stream.on("data", (chunk) => {
+      // split data chunk into lines
+      const items = chunk.split("\n");
+
+      // iterate over lines in this chunk and add them to the lines array
+      for (let i = 0; i < items.length; i++) {
+        // If the first item is not a new line and there was already at least one line read, append it
+        // to the last line because it means the last line was not finished and was split across chunks.
+        // Otherwise, push the item to the lines array.
+        if (lines.length > 0 && i === 0) {
+          lines[lines.length - 1] += items[i];
+        } else {
+          lines.push(items[i]);
+        }
+      }
+
+      // after the last line of this chunk is added, check if we have reached the readSize limit
+      if (readSize < stream.bytesRead) {
+        // if the last item is not a new line (results in empty string), it means the last line
+        // was not finished and was split across chunks so we need to adjust the offset to not
+        // include the last line and pop it from the lines array
+        if (items[items.length - 1] !== "") {
+          adjustBytes = new Blob([items[items.length - 1]]).size;
+          lines.pop(); // pop unfinished item
+        }
+
+        // close the stream to stop reading (this will emit the "end" event and close the file)
+        stream.close();
+        stream.push(null);
+        stream.read(0);
+      }
+    });
+
+    stream.on("end", async () => {
+      // calculate the offset of the last line read
+      const offset = offsetBytes + stream.bytesRead - adjustBytes;
+
+      // if stream was not closed because we reached readSize which means we reached the end of the file
+      const eof = stream.bytesRead <= readSize;
+
+      // resolve the promise with the lines read and a function to confirm the offset
+      resolve({ lines, offset, eof, confirmed: () => setResumableOffset(filename, offset) });
+    });
+
+    // reject the promise if there was an error reading the file
+    stream.on("error", (error) => {
+      reject(error);
+    });
+  });
+}

--- a/container/shim/src/utils/readlines.js
+++ b/container/shim/src/utils/readlines.js
@@ -86,13 +86,6 @@ export default async function readlines(filename, offsetBytes = null, readSize =
   const file = await open(filename, "r");
   const stream = file.createReadStream({ encoding: "utf8", start: offsetBytes });
 
-  // setting read size to less than the stream's readableHighWaterMark will cause the stream to end
-  // after every chunk read (chunk size set in readableHighWaterMark) which will be highly inefficient
-  // so we throw an error if the readSize is less than the readableHighWaterMark
-  if (readSize < stream.readableHighWaterMark) {
-    throw new Error(`readSize must be greater than readableHighWaterMark (${stream.readableHighWaterMark} bytes)`);
-  }
-
   return new Promise((resolve, reject) => {
     const lines = [];
     let adjustBytes = 0;


### PR DESCRIPTION
## Replace the current log ingestor with new one

### Issues with current log ingestor:
- truncates the log file on every read leaving file empty every time
  - node operator is left with empty log file and cannot investigate or verify traffic
  - not all logs are submitted (only retrievals are submitted) but all logs are truncated
  - not all metrics from logs are submitted - no past data to backfill missing ones
- susceptible to log line losses
  - queue of logs pending for submission is kept in memory and lost in case of service failure
  - does not retry submitting logs on submission failures
  - truncates file after read while it could have been written to in the meantime

### New log ingestor:
- streams log file in 64 kb chunks to keep memory usage low even when reading multiple GB files
- batches submission to orchestrator into at most 10 MB of payload per single request
- leaves log file intact, does not truncate
- persists byte offset of read and processed logs to resume ( filename with .offsetfile suffix ie. node-access.log.offsetfile )
- continues reading more only once logs were successfully submitted - retries same logs again on submission failure
- persists inode and file size to detect file rotation and reset byte offset
- backwards compatible with current ingestor, drop in replacement