### PR TITLE
use single [ instead of double [[

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ ARG SATURN_NETWORK="local"
 ARG ORCHESTRATOR_URL
 
 # Load CIDs ban lists
-RUN if [[ "$SATURN_NETWORK" != "local" ]]; then rm /etc/nginx/conf.d/default.conf \
+RUN if [ "$SATURN_NETWORK" != "local" ]; then rm /etc/nginx/conf.d/default.conf \
   && curl -s https://badbits.dwebops.pub/denylist.json | jq '.[].anchor' | xargs -I{} echo 'location ~ "{}" { return 410; }' >> /etc/nginx/denylist.conf; \
     else echo "Local"; fi
 


### PR DESCRIPTION
> Step 28/34 : RUN if [[ "$SATURN_NETWORK" != "local" ]]; then rm /etc/nginx/conf.d/default.conf   && curl -s https://badbits.dwebops.pub/denylist.json | jq '.[].anchor' | xargs -I{} echo 'location ~ "{}" { return 410; }' >> /etc/nginx/denylist.conf;     else echo "Local"; fi
 ---> Running in 60ff9b1edc9b
/bin/sh: 1: [[: not found