### PR TITLE
fix range logging

### DIFF
--- a/container/nginx/nginx.conf
+++ b/container/nginx/nginx.conf
@@ -48,7 +48,7 @@ http {
     # ubs: $upstream_bytes_sent         (integer - 1234) bytes sent from upstream server to nginx including headers
     # ubr: $upstream_bytes_received     (integer - 1234) bytes received from upstream server by nginx including headers
     # bytes: $bytes_sent                (integer - 1234) bytes sent from server to client including headers
-    # range: $http_range                (string - 0-4000) requested bytes range
+    # range: $http_range                (string - bytes=0-4000) requested bytes range
     # cache: $upstream_cache_status     (string - HIT) cache status of the response
     # host: $host                       (string - strn.pl)
     # scheme: $scheme                   (string - https) request scheme
@@ -62,7 +62,7 @@ http {
     log_format node escape=json 'time=$time_iso8601 server=$server_addr uri="$request_uri" method=$request_method '
                                 'status=$status rt=$request_time uct=$upstream_connect_time uht=$upstream_header_time '
                                 'urt=$upstream_response_time ubs=$upstream_bytes_sent ubr=$upstream_bytes_received '
-                                'bytes=$bytes_sent range=$http_range cache=$upstream_cache_status host=$host '
+                                'bytes=$bytes_sent range="$http_range" cache=$upstream_cache_status host=$host '
                                 'scheme=$scheme addr=$remote_addr id=$request_id ref="$http_referer" '
                                 'ua="$http_user_agent" ff="$http_x_forwarded_for" sp=$server_protocol';
 


### PR DESCRIPTION
requested range header needs to be wrapped in quotes since it contains `=` (ie. `bytes=0-4000`) and it breaks logfmt format otherwise