### PR TITLE
Upgrade to lassie v0.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.4.2"
+ARG LASSIE_VERSION="v0.4.3"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \

--- a/container/start.sh
+++ b/container/start.sh
@@ -52,6 +52,7 @@ if [ "${LASSIE_ORIGIN:-}" != "" ]; then
     --event-recorder-url $LASSIE_EVENT_RECORDER_URL \
     --event-recorder-auth $LASSIE_EVENT_RECORDER_AUTH \
     --event-recorder-instance-id "$(cat /usr/src/app/shared/nodeId.txt)" \
+    --temp-dir /usr/src/app/shared
     &>/dev/null &
   LASSIE_PID=$!
 

--- a/container/start.sh
+++ b/container/start.sh
@@ -52,7 +52,7 @@ if [ "${LASSIE_ORIGIN:-}" != "" ]; then
     --event-recorder-url $LASSIE_EVENT_RECORDER_URL \
     --event-recorder-auth $LASSIE_EVENT_RECORDER_AUTH \
     --event-recorder-instance-id "$(cat /usr/src/app/shared/nodeId.txt)" \
-    --temp-dir /usr/src/app/shared
+    --temp-dir /usr/src/app/shared \
     &>/dev/null &
   LASSIE_PID=$!
 


### PR DESCRIPTION
uses temp dir in home directory (I think)