### PR TITLE
disable https redirect for raw/block requests

### DIFF
--- a/container/nginx/confs/tls_proxy.conf
+++ b/container/nginx/confs/tls_proxy.conf
@@ -66,6 +66,16 @@ server {
 
     include /etc/nginx/conf.d/register.conf;
 
+    # TODO: Temporary block to facilitate bifrost gateway tests.
+    location /ipfs/ {
+        proxy_set_header Host handoff.strn.localhost;
+        if ( $arg_format ~ "raw|car" ) {
+            proxy_pass http://127.0.0.1;
+            break;
+        }
+        return 301 https://$host$request_uri;
+    }
+
     location / {
         return 301 https://$host$request_uri;
     }


### PR DESCRIPTION
Requested by bifrost team for benchmarking

https://github.com/ipfs/bifrost-gateway/pull/46#discussion_r1111324029