### PR TITLE
Upgrade lassie v0.4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.4.3"
+ARG LASSIE_VERSION="v0.4.5"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \

--- a/container/start.sh
+++ b/container/start.sh
@@ -46,14 +46,14 @@ fi
 nginx
 
 export LASSIE_ORIGIN=http://127.0.0.1:7766
-
+export LASSIE_EVENT_RECORDER_INSTANCE_ID = "$(cat /usr/src/app/shared/nodeId.txt)"
+export LASSIE_TEMP_DIRECTORY=/usr/src/app/shared
+export LASSIE_MAX_BLOCKS_PER_REQUEST=10000
+export LASSIE_LIBP2P_CONNECTIONS_LOWWATER=2000
+export LASSIE_LIBP2P_CONNECTIONS_HIGHWATER=3000
+export LASSIE_PORT=7766
 if [ "${LASSIE_ORIGIN:-}" != "" ]; then
-  lassie daemon -p 7766 \
-    --event-recorder-url $LASSIE_EVENT_RECORDER_URL \
-    --event-recorder-auth $LASSIE_EVENT_RECORDER_AUTH \
-    --event-recorder-instance-id "$(cat /usr/src/app/shared/nodeId.txt)" \
-    --tempdir /usr/src/app/shared \
-    &>/dev/null &
+  lassie daemon &>/dev/null &
   LASSIE_PID=$!
 
   node --max-old-space-size=4096 /usr/src/app/src/bin/shim.js &


### PR DESCRIPTION
# Goals

Upgrades to a version of Lassie with better libp2p settings to reduce latency. 

# Implementation

Also introduces LASSIE_MAX_BLOCKS_PER_REQUEST = 10000. This number should be discussed and agreed upon. Default chunking for IPFS is usually 256K so this comes in around ~4GB, which seems generous for now.