### PR TITLE
Fix for ERROR: Invalid interpolation format for "labels" option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     labels:
       com.centurylinklabs.watchtower.scope: saturn
       com.centurylinklabs.watchtower.enable: "true"
-      com.centurylinklabs.watchtower.lifecycle.pre-update: "sleep $((RANDOM % 3600))"
+      com.centurylinklabs.watchtower.lifecycle.pre-update: "sleep $$((RANDOM % 3600))"
       com.centurylinklabs.watchtower.lifecycle.pre-update-timeout: 3600
     volumes:
       - ${SATURN_HOME:-$HOME}/shared:/usr/src/app/shared


### PR DESCRIPTION
Fix for #239 

Full error:

  ERROR: Invalid interpolation format for "labels" option in service "saturn-node": "sleep $((RANDOM % 3600))"