### PR TITLE
Auto-update docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ Multi-noding (Sharing CPU, RAM, Uplink or storage among nodes) is not allowed.**
    curl -s https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml
    ```
 
-5. Download the `docker_compose_update.sh` file:
+5. Download the `docker_compose_update.sh` script and make it executable:
 
    ```bash
    curl -s https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker_compose_update.sh -o docker_compose_update.sh
+   chmod +x docker_compose_update.sh
    ```
 
 6. Set up the cron job to auto-update the `docker-compose.yml` file:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Multi-noding (Sharing CPU, RAM, Uplink or storage among nodes) is not allowed.**
    Add the following text to your editor, making sure to replace `$SATURN_HOME` with its value:
 
    ```
-   */5 * * * * curl -s https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml > $SATURN_HOME/docker-compose.yml && sudo docker compose up -d
+   */5 * * * * cd $SATURN_HOME && curl -s https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml.curl && diff docker-compose.yml.curl docker-compose.yml >/dev/null || (mv -f docker-compose.yml.curl docker-compose.yml && sudo docker compose up -d)
    ```
 
 6. Launch it:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,13 @@ Multi-noding (Sharing CPU, RAM, Uplink or storage among nodes) is not allowed.**
    curl -s https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml
    ```
 
-5. Set up the cron job to auto-update the `docker-compose.yml` file:
+5. Download the `docker_compose_update.sh` file:
+
+   ```bash
+   curl -s https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker_compose_update.sh -o docker_compose_update.sh
+   ```
+
+6. Set up the cron job to auto-update the `docker-compose.yml` file:
 
    ```bash
    crontab -e
@@ -108,17 +114,17 @@ Multi-noding (Sharing CPU, RAM, Uplink or storage among nodes) is not allowed.**
    Add the following text to your editor, making sure to replace `$SATURN_HOME` with its actual value:
 
    ```
-   */5 * * * * cd $SATURN_HOME && curl -fs https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml.curl && diff docker-compose.yml.curl docker-compose.yml >/dev/null || (mv -f docker-compose.yml.curl docker-compose.yml && sudo docker compose up -d)
+   */5 * * * * cd $SATURN_HOME && sh docker_compose_update.sh
    ```
 
-6. Launch it:
+7. Launch it:
 
    ```bash
    sudo docker compose up -d
    ```
 
-7. Check logs with `docker logs -f saturn-node`
-8. Check there are no errors, registration will happen automatically and node will restart once it receives its TLS certificate
+8. Check logs with `docker logs -f saturn-node`
+9. Check there are no errors, registration will happen automatically and node will restart once it receives its TLS certificate
 
 In most instances speedtest does a good job of picking "close" servers but for small networks it may be incorrect.
 If the speedtest value reported by speedtest seems low, you may want to configure SPEEDTEST_SERVER_CONFIG to point to a different public speedtest server. You will need to install [speedtest CLI](https://www.speedtest.net/apps/cli) in the host and fetch close servers' IDs by doing `speedtest --servers`, then setting `SPEEDTEST_SERVER_CONFIG="--server-id=XXXXX"`

--- a/README.md
+++ b/README.md
@@ -93,20 +93,32 @@ Multi-noding (Sharing CPU, RAM, Uplink or storage among nodes) is not allowed.**
 
    You can use the text editor of your choice (e.g. `nano` or `vim` on Linux)
 
-4. Download the docker-compose file
+4. Download the `docker-compose.yaml` file:
 
    ```bash
    curl -s https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml
    ```
 
-5. Launch it:
+5. Set up the cron job to auto-update the `docker-compose.yaml` file:
+
+   ```bash
+   crontab -e
+   ```
+
+   Add the following text to your editor, making sure to replace `$SATURN_HOME` with its value:
+
+   ```
+   */5 * * * * curl -s https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml > $SATURN_HOME/docker-compose.yml && sudo docker compose up -d
+   ```
+
+6. Launch it:
 
    ```bash
    sudo docker compose up -d
    ```
 
-6. Check logs with `docker logs -f saturn-node`
-7. Check there are no errors, registration will happen automatically and node will restart once it receives its TLS certificate
+7. Check logs with `docker logs -f saturn-node`
+8. Check there are no errors, registration will happen automatically and node will restart once it receives its TLS certificate
 
 In most instances speedtest does a good job of picking "close" servers but for small networks it may be incorrect.
 If the speedtest value reported by speedtest seems low, you may want to configure SPEEDTEST_SERVER_CONFIG to point to a different public speedtest server. You will need to install [speedtest CLI](https://www.speedtest.net/apps/cli) in the host and fetch close servers' IDs by doing `speedtest --servers`, then setting `SPEEDTEST_SERVER_CONFIG="--server-id=XXXXX"`
@@ -115,6 +127,7 @@ If the speedtest value reported by speedtest seems low, you may want to configur
 
 We are using a Watchtower container to update the saturn-node container.
 Your node will be updated automatically. You can see the update logs with `docker logs -f saturn-watchtower`.
+Make sure to setup the cron job to auto-update `docker-compose.yaml` as well (see above).
 
 ## Set up a node with [Ansible](https://docs.ansible.com/ansible/latest/index.html)
 

--- a/README.md
+++ b/README.md
@@ -93,13 +93,13 @@ Multi-noding (Sharing CPU, RAM, Uplink or storage among nodes) is not allowed.**
 
    You can use the text editor of your choice (e.g. `nano` or `vim` on Linux)
 
-4. Download the `docker-compose.yaml` file:
+4. Download the `docker-compose.yml` file:
 
    ```bash
    curl -s https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml
    ```
 
-5. Set up the cron job to auto-update the `docker-compose.yaml` file:
+5. Set up the cron job to auto-update the `docker-compose.yml` file:
 
    ```bash
    crontab -e
@@ -127,7 +127,7 @@ If the speedtest value reported by speedtest seems low, you may want to configur
 
 We are using a Watchtower container to update the saturn-node container.
 Your node will be updated automatically. You can see the update logs with `docker logs -f saturn-watchtower`.
-Make sure to setup the cron job to auto-update `docker-compose.yaml` as well (see above).
+Make sure to setup the cron job to auto-update `docker-compose.yml` as well (see above).
 
 ## Set up a node with [Ansible](https://docs.ansible.com/ansible/latest/index.html)
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Multi-noding (Sharing CPU, RAM, Uplink or storage among nodes) is not allowed.**
    Add the following text to your editor, making sure to replace `$SATURN_HOME` with its actual value:
 
    ```
-   */5 * * * * cd $SATURN_HOME && sh docker_compose_update.sh
+   */5 * * * * cd $SATURN_HOME && sh docker_compose_update.sh >> docker_compose_update.log 2>&1
    ```
 
 7. Launch it:

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ Multi-noding (Sharing CPU, RAM, Uplink or storage among nodes) is not allowed.**
    sudo docker compose up -d
    ```
 
-6. Check logs with `docker logs -f saturn-node`
-7. Check for any errors. Registration will happen automatically and the node will restart once it receives its TLS certificate
+8. Check logs with `docker logs -f saturn-node`
+9. Check for any errors. Registration will happen automatically and the node will restart once it receives its TLS certificate
 
 In most instances speedtest does a good job of picking "close" servers but for small networks it may be incorrect.
 If the speedtest value reported by speedtest seems low, you may want to configure SPEEDTEST_SERVER_CONFIG to point to a different public speedtest server. You will need to install [speedtest CLI](https://www.speedtest.net/apps/cli) in the host and fetch close servers' IDs by doing `speedtest --servers`, then setting `SPEEDTEST_SERVER_CONFIG="--server-id=XXXXX"`

--- a/README.md
+++ b/README.md
@@ -109,13 +109,7 @@ Multi-noding (Sharing CPU, RAM, Uplink or storage among nodes) is not allowed.**
 6. Set up the cron job to auto-update the `docker-compose.yml` file:
 
    ```bash
-   crontab -e
-   ```
-
-   Add the following text to your editor, making sure to replace `$SATURN_HOME` with its actual value:
-
-   ```
-   */5 * * * * cd $SATURN_HOME && sh docker_compose_update.sh >> docker_compose_update.log 2>&1
+   (crontab -l 2>/dev/null; echo "*/5 * * * * cd $SATURN_HOME && sh docker_compose_update.sh >> docker_compose_update.log 2>&1") | crontab -
    ```
 
 7. Launch it:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Multi-noding (Sharing CPU, RAM, Uplink or storage among nodes) is not allowed.**
    crontab -e
    ```
 
-   Add the following text to your editor, making sure to replace `$SATURN_HOME` with its value:
+   Add the following text to your editor, making sure to replace `$SATURN_HOME` with its actual value:
 
    ```
    */5 * * * * cd $SATURN_HOME && curl -s https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml.curl && diff docker-compose.yml.curl docker-compose.yml >/dev/null || (mv -f docker-compose.yml.curl docker-compose.yml && sudo docker compose up -d)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Multi-noding (Sharing CPU, RAM, Uplink or storage among nodes) is not allowed.**
    Add the following text to your editor, making sure to replace `$SATURN_HOME` with its actual value:
 
    ```
-   */5 * * * * cd $SATURN_HOME && curl -s https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml.curl && diff docker-compose.yml.curl docker-compose.yml >/dev/null || (mv -f docker-compose.yml.curl docker-compose.yml && sudo docker compose up -d)
+   */5 * * * * cd $SATURN_HOME && curl -fs https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml.curl && diff docker-compose.yml.curl docker-compose.yml >/dev/null || (mv -f docker-compose.yml.curl docker-compose.yml && sudo docker compose up -d)
    ```
 
 6. Launch it:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       WATCHTOWER_LABEL_ENABLE: "true"
       WATCHTOWER_LIFECYCLE_HOOKS: "true"
       WATCHTOWER_SCOPE: saturn
+      WATCHTOWER_INCLUDE_RESTARTING: "true"
     labels:
       com.centurylinklabs.watchtower.scope: saturn
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     container_name: saturn-node
     restart: unless-stopped
     environment:
-      SATURN_NETWORK: "${SATURN_NETWORK:?please make sure to set your SATURN_NETWORK environment variable with either 'test' or 'main' in the .env file}"
       FIL_WALLET_ADDRESS: "${FIL_WALLET_ADDRESS:?please make sure to set your FIL_WALLET_ADDRESS environment variable in the .env file}"
       NODE_OPERATOR_EMAIL: "${NODE_OPERATOR_EMAIL:?please make sure to set your NODE_OPERATOR_EMAIL environment variable in the .env file}"
       SPEEDTEST_SERVER_CONFIG: "${SPEEDTEST_SERVER_CONFIG}"

--- a/docker_compose_update.sh
+++ b/docker_compose_update.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+
+# keeps docker-compose.yml and itself up to date
 set -eux
 
 branch="update_docker_compose"

--- a/docker_compose_update.sh
+++ b/docker_compose_update.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -eu
+#!/bin/sh
+set -eux
 
 branch="update_docker_compose"
 repo="https://raw.githubusercontent.com/filecoin-saturn/L1-node/$branch"

--- a/docker_compose_update.sh
+++ b/docker_compose_update.sh
@@ -10,6 +10,6 @@ curl -fs "$repo/docker_compose_update.sh" -o docker_compose_update.sh
 
 curl -fs "$repo/docker-compose.yml" -o docker-compose.yml.curl
 if ! diff docker-compose.yml.curl docker-compose.yml >/dev/null; then
-				mv -f docker-compose.yml.curl docker-compose.yml
-				sudo docker compose up -d
+    mv -f docker-compose.yml.curl docker-compose.yml
+    sudo docker compose up -d
 fi

--- a/docker_compose_update.sh
+++ b/docker_compose_update.sh
@@ -3,7 +3,7 @@
 # keeps docker-compose.yml and itself up to date
 set -eux
 
-branch="update_docker_compose"
+branch="main"
 repo="https://raw.githubusercontent.com/filecoin-saturn/L1-node/$branch"
 
 curl -fs "$repo/docker_compose_update.sh" -o docker_compose_update.sh

--- a/docker_compose_update.sh
+++ b/docker_compose_update.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eu
+
+curl -fs https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml.curl
+
+if ! diff docker-compose.yml.curl docker-compose.yml >/dev/null; then
+				mv -f docker-compose.yml.curl docker-compose.yml
+				sudo docker compose up -d
+fi

--- a/docker_compose_update.sh
+++ b/docker_compose_update.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -eu
 
-curl -fs https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker_compose_update.sh -o docker_compose_update.sh
+branch="update_docker_compose"
+repo="https://raw.githubusercontent.com/filecoin-saturn/L1-node/$branch"
 
-curl -fs https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml.curl
+curl -fs "$repo/docker_compose_update.sh" -o docker_compose_update.sh
+
+curl -fs "$repo/docker-compose.yml" -o docker-compose.yml.curl
 if ! diff docker-compose.yml.curl docker-compose.yml >/dev/null; then
 				mv -f docker-compose.yml.curl docker-compose.yml
 				sudo docker compose up -d

--- a/docker_compose_update.sh
+++ b/docker_compose_update.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -eu
 
-curl -fs https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml.curl
+curl -fs https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker_compose_update.sh -o docker_compose_update.sh
 
+curl -fs https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml -o docker-compose.yml.curl
 if ! diff docker-compose.yml.curl docker-compose.yml >/dev/null; then
 				mv -f docker-compose.yml.curl docker-compose.yml
 				sudo docker compose up -d

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -124,6 +124,7 @@
     homedir: "{{ ansible_env.HOME }}"
     saturn_home: "{{ saturn_root if saturn_root is defined else homedir }}"
     env_file: "{{ lookup('file', '../.env' ) }}"
+    docker_compose: https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml
   tasks:
     - name: Copy the .env file
       ansible.builtin.copy:
@@ -137,8 +138,13 @@
       become: true
       become_user: root
       ansible.builtin.get_url:
-        url: https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml
+        url: "{{ docker_compose }}"
         dest: "{{ saturn_home }}/docker-compose.yml"
+    - name: Add the cron to update docker-compose.yml
+      ansible.builtin.cron:
+        name: "update docker compose"
+        minute: "*/5"
+        job: "curl -s {{ docker_compose }} > {{ saturn_home }}/docker-compose.yml && sudo docker compose up -d"
     - name: Ensure we have the right $SATURN_HOME/shared permissions
       become: true
       become_user: root

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -124,8 +124,9 @@
     homedir: "{{ ansible_env.HOME }}"
     saturn_home: "{{ saturn_root if saturn_root is defined else homedir }}"
     env_file: "{{ lookup('file', '../.env' ) }}"
-    docker_compose: https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml
-    docker_compose_update: https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker_compose_update.sh
+    branch: main
+    docker_compose: "https://raw.githubusercontent.com/filecoin-saturn/L1-node/{{ branch }}/docker-compose.yml"
+    docker_compose_update: "https://raw.githubusercontent.com/filecoin-saturn/L1-node/{{ branch }}/docker_compose_update.sh"
   tasks:
     - name: Copy the .env file
       ansible.builtin.copy:

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -125,6 +125,7 @@
     saturn_home: "{{ saturn_root if saturn_root is defined else homedir }}"
     env_file: "{{ lookup('file', '../.env' ) }}"
     docker_compose: https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker-compose.yml
+    docker_compose_update: https://raw.githubusercontent.com/filecoin-saturn/L1-node/main/docker_compose_update.sh
   tasks:
     - name: Copy the .env file
       ansible.builtin.copy:
@@ -135,16 +136,18 @@
         path: "{{ saturn_home }}/.env"
         block: SATURN_HOME="{{ saturn_home }}"
     - name: Get docker-compose.yml
-      become: true
-      become_user: root
       ansible.builtin.get_url:
         url: "{{ docker_compose }}"
         dest: "{{ saturn_home }}/docker-compose.yml"
+    - name: Get docker_compose_update.sh
+      ansible.builtin.get_url:
+        url: "{{ docker_compose_update }}"
+        dest: "{{ saturn_home }}/docker_compose_update.sh"
     - name: Add the cronjob to update docker-compose.yml
       ansible.builtin.cron:
         name: "update docker compose"
         minute: "*/5"
-        job: "cd '{{ saturn_home }}' && curl -fs {{ docker_compose }} -o docker-compose.yml.curl && diff docker-compose.yml.curl docker-compose.yml >/dev/null || (mv -f docker-compose.yml.curl docker-compose.yml && sudo docker compose up -d)"
+        job: "cd {{ saturn_home }} && sh docker_compose_update.sh"
     - name: Ensure we have the right $SATURN_HOME/shared permissions
       become: true
       become_user: root

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -148,7 +148,7 @@
       ansible.builtin.cron:
         name: "update docker compose"
         minute: "*/5"
-        job: "cd {{ saturn_home }} && sh docker_compose_update.sh"
+        job: "cd {{ saturn_home }} && sh docker_compose_update.sh >> docker_compose_update.log 2>&1"
     - name: Ensure we have the right $SATURN_HOME/shared permissions
       become: true
       become_user: root

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -144,7 +144,7 @@
       ansible.builtin.cron:
         name: "update docker compose"
         minute: "*/5"
-        job: "curl -s {{ docker_compose }} > {{ saturn_home }}/docker-compose.yml && sudo docker compose up -d"
+        job: "cd '{{ saturn_home }}' && curl -s {{ docker_compose }} -o docker-compose.yml.curl && diff docker-compose.yml.curl docker-compose.yml >/dev/null || (mv -f docker-compose.yml.curl docker-compose.yml && sudo docker compose up -d)"
     - name: Ensure we have the right $SATURN_HOME/shared permissions
       become: true
       become_user: root

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -143,6 +143,7 @@
       ansible.builtin.get_url:
         url: "{{ docker_compose_update }}"
         dest: "{{ saturn_home }}/docker_compose_update.sh"
+        mode: +x
     - name: Add the cronjob to update docker-compose.yml
       ansible.builtin.cron:
         name: "update docker compose"

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -140,7 +140,7 @@
       ansible.builtin.get_url:
         url: "{{ docker_compose }}"
         dest: "{{ saturn_home }}/docker-compose.yml"
-    - name: Add the cron to update docker-compose.yml
+    - name: Add the cronjob to update docker-compose.yml
       ansible.builtin.cron:
         name: "update docker compose"
         minute: "*/5"

--- a/playbooks/l1.yaml
+++ b/playbooks/l1.yaml
@@ -144,7 +144,7 @@
       ansible.builtin.cron:
         name: "update docker compose"
         minute: "*/5"
-        job: "cd '{{ saturn_home }}' && curl -s {{ docker_compose }} -o docker-compose.yml.curl && diff docker-compose.yml.curl docker-compose.yml >/dev/null || (mv -f docker-compose.yml.curl docker-compose.yml && sudo docker compose up -d)"
+        job: "cd '{{ saturn_home }}' && curl -fs {{ docker_compose }} -o docker-compose.yml.curl && diff docker-compose.yml.curl docker-compose.yml >/dev/null || (mv -f docker-compose.yml.curl docker-compose.yml && sudo docker compose up -d)"
     - name: Ensure we have the right $SATURN_HOME/shared permissions
       become: true
       become_user: root


### PR DESCRIPTION
This is needed to deploy container configuration fixes and to iterate on service configuration.

The approach is to have operators deploy a cron job to automatically restart docker compose when there is a new version of that file.

Addresses https://github.com/filecoin-saturn/L1-node/issues/225 and the fact watchtower isn't updating containers on a crash loop.