### PR TITLE
Add back L2 response path

### DIFF
--- a/container/shim/src/index.js
+++ b/container/shim/src/index.js
@@ -72,12 +72,12 @@ const handleCID = asyncHandler(async (req, res) => {
   const isSampled = Math.random() < LASSIE_SAMPLE_RATE;
   const useLassie = isBifrostGateway || isSampled;
 
-  if (useLassie && LASSIE_ORIGIN) {
-    return respondFromLassie(req, res, { cidObj, format });
-  }
-
   if (SATURN_NETWORK !== "main" && !req.params.path && (await maybeRespondFromL2(req, res, { cid, format }))) {
     return;
+  }
+  
+  if (useLassie && LASSIE_ORIGIN) {
+    return respondFromLassie(req, res, { cidObj, format });
   }
 
   respondFromIPFSGateway(req, res, { cid, format });

--- a/container/shim/src/index.js
+++ b/container/shim/src/index.js
@@ -68,13 +68,13 @@ const handleCID = asyncHandler(async (req, res) => {
     return res.send(testCAR);
   }
 
-  const isBifrostGateway = req.headers["user-agent"]?.includes("bifrost-gateway");
-  const isSampled = Math.random() < LASSIE_SAMPLE_RATE;
-  const useLassie = isBifrostGateway || isSampled;
-
   if (SATURN_NETWORK !== "main" && !req.params.path && (await maybeRespondFromL2(req, res, { cid, format }))) {
     return;
   }
+
+  const isBifrostGateway = req.headers["user-agent"]?.includes("bifrost-gateway");
+  const isSampled = Math.random() < LASSIE_SAMPLE_RATE;
+  const useLassie = isBifrostGateway || isSampled;
   
   if (useLassie && LASSIE_ORIGIN) {
     return respondFromLassie(req, res, { cidObj, format });

--- a/container/shim/src/index.js
+++ b/container/shim/src/index.js
@@ -75,7 +75,7 @@ const handleCID = asyncHandler(async (req, res) => {
   const isBifrostGateway = req.headers["user-agent"]?.includes("bifrost-gateway");
   const isSampled = Math.random() < LASSIE_SAMPLE_RATE;
   const useLassie = isBifrostGateway || isSampled;
-  
+
   if (useLassie && LASSIE_ORIGIN) {
     return respondFromLassie(req, res, { cidObj, format });
   }


### PR DESCRIPTION
Without this, L2s in testnet receive no traffic.

However, Lassie will still be called also, since `L2_FIRE_AND_FORGET` is on