### PR TITLE
Update lassie/disable graphsync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.4.7"
+ARG LASSIE_VERSION="v0.5.0"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \

--- a/container/start.sh
+++ b/container/start.sh
@@ -54,6 +54,7 @@ export LASSIE_LIBP2P_CONNECTIONS_HIGHWATER=3000
 export LASSIE_PORT=7766
 export LASSIE_CONCURRENT_SP_RETRIEVALS=1
 export LASSIE_EXPOSE_METRICS=true
+export LASSIE_DISABLE_GRAPHSYNC=true
 
 # Clean up leftover files in old lassie dir. Can remove this line after L1s update.
 find /usr/src/app/shared -name "lassie_carstore*" -exec rm {} +


### PR DESCRIPTION
# Goals

Updates Lassie to version 0.5.0 (actually supports pathing!) but more importantly disables all graphsync requests to limit SP traffic

P0, please deploy ASAP