### PR TITLE
Ring L1s only support "raw" and "car" formats

### DIFF
--- a/container/shim/src/config.js
+++ b/container/shim/src/config.js
@@ -15,6 +15,7 @@ export const FIL_WALLET_ADDRESS = process.env.FIL_WALLET_ADDRESS || error("FIL_W
 export const NODE_OPERATOR_EMAIL = process.env.NODE_OPERATOR_EMAIL || error("NODE_OPERATOR_EMAIL");
 export const IPFS_GATEWAY_ORIGIN = process.env.IPFS_GATEWAY_ORIGIN || "https://ipfs.io";
 export const LASSIE_ORIGIN = process.env.LASSIE_ORIGIN || null;
+export const IS_CORE_L1 = process.env.IS_CORE_L1 === "true";
 export const TESTING_CID = "QmXjYBY478Cno4jzdCcPy4NcJYFrwHZ51xaCP8vUwN9MGm";
 
 export const nodeId = await readOrCreateNodeId();

--- a/container/shim/src/index.js
+++ b/container/shim/src/index.js
@@ -10,7 +10,7 @@ import { respondFromIPFSGateway } from "./fetchers/ipfs-gateway.js";
 import { respondFromLassie } from "./fetchers/lassie.js";
 import { cancelCarRequest, maybeRespondFromL2, registerL2Node } from "./fetchers/l2-node.js";
 import { addRegisterCheckRoute } from "./modules/registration.js";
-import { LASSIE_ORIGIN, SATURN_NETWORK, TESTING_CID } from "./config.js";
+import { LASSIE_ORIGIN, SATURN_NETWORK, TESTING_CID, IS_CORE_L1 } from "./config.js";
 import { getResponseFormat } from "./utils/http.js";
 import { debug } from "./utils/logging.js";
 
@@ -48,6 +48,12 @@ const handleCID = asyncHandler(async (req, res) => {
   }
 
   const format = getResponseFormat(req);
+  const isVerifiableFormat = ["car", "raw"].includes(format);
+  const isNotImplemented = !isVerifiableFormat && !IS_CORE_L1;
+
+  if (isNotImplemented) {
+    return res.sendStatus(501);
+  }
 
   res.set("Content-Type", mimeTypes.lookup(req.path) || "application/octet-stream");
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       FIL_WALLET_ADDRESS: "${FIL_WALLET_ADDRESS:?please make sure to set your FIL_WALLET_ADDRESS environment variable in the .env file}"
       NODE_OPERATOR_EMAIL: "${NODE_OPERATOR_EMAIL:?please make sure to set your NODE_OPERATOR_EMAIL environment variable in the .env file}"
       SPEEDTEST_SERVER_CONFIG: "${SPEEDTEST_SERVER_CONFIG}"
-      IS_CORE_L1: "${IS_CORE_L1:=false}"
     ulimits:
       nofile:
         soft: 1000000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       FIL_WALLET_ADDRESS: "${FIL_WALLET_ADDRESS:?please make sure to set your FIL_WALLET_ADDRESS environment variable in the .env file}"
       NODE_OPERATOR_EMAIL: "${NODE_OPERATOR_EMAIL:?please make sure to set your NODE_OPERATOR_EMAIL environment variable in the .env file}"
       SPEEDTEST_SERVER_CONFIG: "${SPEEDTEST_SERVER_CONFIG}"
+      IS_CORE_L1: "${IS_CORE_L1:=false}"
     ulimits:
       nofile:
         soft: 1000000

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -8,6 +8,7 @@ set -e
 : "${ORCHESTRATOR_REGISTRATION:=true}"
 : "${HTTP_PORT:=80}"
 : "${HTTPS_PORT:=443}"
+: "${IS_CORE_L1:=true}"
 
 mkdir -p $(pwd)/shared
 echo "$(date -u) [host] Running Saturn node dev, with volume in $(pwd)/shared"
@@ -21,5 +22,6 @@ docker run --name saturn-node -it --rm \
           -e "ORCHESTRATOR_REGISTRATION=$ORCHESTRATOR_REGISTRATION" \
           -e "SPEEDTEST_SERVER_CONFIG=$SPEEDTEST_SERVER_CONFIG" \
           -e "LASSIE_ORIGIN=$LASSIE_ORIGIN" \
+          -e "IS_CORE_L1=$IS_CORE_L1" \
           -p $HTTPS_PORT:443 -p $HTTP_PORT:80 \
           saturn-node


### PR DESCRIPTION
Handles https://github.com/filecoin-saturn/L1-node/issues/232
Depends on https://github.com/filecoin-saturn/orchestrator/issues/90

Adds an env var to differentiate core vs ring nodes. Note that this is a temporary solution until flat files are disabled globally.

`strn.pl` needs to only point to core L1s before we disable flat files for ring nodes.