### PR TITLE
Update lassie v0.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.6.5"
+ARG LASSIE_VERSION="v0.6.6"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \


### PR DESCRIPTION
contains an important fix we THINK may double success on cache miss into lassie.

otherwise a small release. has been run through load tests with no errors. non-critical, but we'd like to get it out soon to see what effect the fix has.