### PR TITLE
Load feature-flags for staged deployments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       FIL_WALLET_ADDRESS: "${FIL_WALLET_ADDRESS:?please make sure to set your FIL_WALLET_ADDRESS environment variable in the .env file}"
       NODE_OPERATOR_EMAIL: "${NODE_OPERATOR_EMAIL:?please make sure to set your NODE_OPERATOR_EMAIL environment variable in the .env file}"
       SPEEDTEST_SERVER_CONFIG: "${SPEEDTEST_SERVER_CONFIG}"
+    env_file:
+      - .env
     ulimits:
       nofile:
         soft: 1000000


### PR DESCRIPTION
- Make use of https://docs.docker.com/compose/compose-file/#env_file to load any env vars into the container;
- This will unfortunately load `SATURN_NETWORK` as well, but I figured this isn't a big issue given we need to work on https://github.com/filecoin-saturn/L1-node/issues/225#issuecomment-1460805305.