### PR TITLE
Disable connections on Elastic IPFS for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.6.7"
+ARG LASSIE_VERSION="v0.6.8"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \

--- a/container/start.sh
+++ b/container/start.sh
@@ -63,7 +63,7 @@ export LASSIE_EXPOSE_METRICS=true
 export LASSIE_METRICS_PORT=7776
 export LASSIE_METRICS_ADDRESS=0.0.0.0
 export LASSIE_DISABLE_GRAPHSYNC=true
-
+export LASSIE_EXCLUDE_PROVIDERS=bafzbeibhqavlasjc7dvbiopygwncnrtvjd2xmryk5laib7zyjor6kf3avm
 mkdir -p $LASSIE_TEMP_DIRECTORY
 
 if [ "${LASSIE_ORIGIN:-}" != "" ]; then


### PR DESCRIPTION
Updates lassie and adds to the excluded list the main peer for Elastic IPFS, which we need to disable cause of the bill we're running up :)