### PR TITLE
Custom speedtest server ID

### DIFF
--- a/container/shim/src/utils/system.js
+++ b/container/shim/src/utils/system.js
@@ -101,7 +101,7 @@ export async function getNICStats() {
 
 export async function getSpeedtest() {
   debug("Executing speedtest");
-  const { stdout: result } = await exec(`speedtest ${SPEEDTEST_SERVER_CONFIG} --accept-license --accept-gdpr -f json`);
+  const { stdout: result } = await exec(`speedtest --server-id ${SPEEDTEST_SERVER_CONFIG} --accept-license --accept-gdpr -f json`);
   const values = JSON.parse(result);
   debug(
     `Done executing speedtest. ${bytesToMbps(values.download.bandwidth)} Mbps DL / ${bytesToMbps(


### PR DESCRIPTION
In the command used to measure the speed (speedtest) it is necessary to add "--server-id" to take into account the server ID. Otherwise, it will ignore it and select it automatically.

In docker-compose.yml it is added, but personally I have ignored it and that has led me to confusion. I think it would be better to indicate only the ID in the docker-compose.yml.