### PR TITLE
Update lassie to v0.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.6.11"
+ARG LASSIE_VERSION="v0.7.0"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \

--- a/container/shim/src/config.js
+++ b/container/shim/src/config.js
@@ -25,6 +25,7 @@ export const NODE_OPERATOR_EMAIL = process.env.NODE_OPERATOR_EMAIL || error("NOD
 export const IS_CORE_L1 = process.env.IS_CORE_L1 === "true";
 export const SPEEDTEST_SERVER_CONFIG = process.env.SPEEDTEST_SERVER_CONFIG || "";
 export const LASSIE_ORIGIN = process.env.LASSIE_ORIGIN || null;
+export const LASSIE_SP_ELIGIBLE_PORTION = spPortionFromString(process.env.LASSIE_SP_ELIGIBLE_PORTION || null);
 
 export const NODE_UA = `Saturn/${VERSION}`;
 
@@ -75,4 +76,12 @@ function error(requiredVarName) {
 
 function pVersion(version) {
   return version.slice(0, version.indexOf("_") + 8);
+}
+
+function spPortionFromString(portion) {
+  const portionAsFloat = parseFloat(portion);
+  if (Number.isNaN(portionAsFloat)) {
+    return 0.0;
+  }
+  return portionAsFloat;
 }

--- a/container/start.sh
+++ b/container/start.sh
@@ -55,6 +55,7 @@ export NODE_VERSION_HASH=$(echo -n "$VERSION_HASH$(cat /usr/src/app/shared/nodeI
 
 export LASSIE_PORT=7766
 export LASSIE_ORIGIN=http://127.0.0.1:$LASSIE_PORT
+export LASSIE_SP_ELIGIBLE_PORTION=0.0
 export LASSIE_EVENT_RECORDER_INSTANCE_ID="$(cat /usr/src/app/shared/nodeId.txt)"
 export LASSIE_TEMP_DIRECTORY=/usr/src/app/shared/lassie
 export LASSIE_MAX_BLOCKS_PER_REQUEST=10000
@@ -64,7 +65,7 @@ export LASSIE_CONCURRENT_SP_RETRIEVALS=1
 export LASSIE_EXPOSE_METRICS=true
 export LASSIE_METRICS_PORT=7776
 export LASSIE_METRICS_ADDRESS=0.0.0.0
-export LASSIE_SUPPORTED_PROTOCOLS="bitswap"
+export LASSIE_SUPPORTED_PROTOCOLS="bitswap,graphsync"
 mkdir -p $LASSIE_TEMP_DIRECTORY
 
 if [ "${LASSIE_ORIGIN:-}" != "" ]; then


### PR DESCRIPTION
# What

This PR makes the infrustructure changes needed to turn SP retrievals back on, including a randomized filter that will limit SP retrievals to a certain percentage of retrievals coming into a Saturn instance over time. Note: it does not actually allow any SP requests through. I want to get this deployed, ideally today, and verify no problems are encountered, then slowly start pushing the SP requests back up.