### PR TITLE
Revert Lassie v0.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.8.0"
+ARG LASSIE_VERSION="v0.7.0"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \


### PR DESCRIPTION
# Goals

This reverts commit cd3b3f5282718041b1d21849c58b593ac52fa96c.

We have to revert this version of Lassie for now, which is over downloading. This won't affect your nodes one way or another, and actually v0.8.0 is fine from saturns standpoint, but it was driving up Web3.Storage costs a LOT.