### PR TITLE
update lassie v0.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.7.0"
+ARG LASSIE_VERSION="v0.8.1"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \

--- a/container/shim/src/fetchers/lassie.js
+++ b/container/shim/src/fetchers/lassie.js
@@ -160,13 +160,17 @@ function createLassieURL(req, isRawFormat) {
     // translate depth parameter for lassie
     let newKey = key;
     let newVal = val;
-    if (key === "depth" && (val === "1" || val === "0")) {
-      newKey = "depthType";
-      newVal = "shallow";
+    if (key === "depth" && val === "1") {
+      newKey = "car-scope";
+      newVal = "file";
+    }
+    if (key === "depth" && val === "0") {
+      newKey = "car-scope";
+      newVal = "root";
     }
     if (key === "depth" && val === "all") {
-      newKey = "depthType";
-      newVal = "full";
+      newKey = "car-scope";
+      newVal = "all";
     }
     lassieUrl.searchParams.set(newKey, toUtf8(newVal));
   }
@@ -178,13 +182,13 @@ function createLassieURL(req, isRawFormat) {
   }
 
   // if no depth type set
-  if (!lassieUrl.searchParams.has("depthType")) {
+  if (!lassieUrl.searchParams.has("car-scope")) {
     if (isRawFormat) {
       // for raw, default to shallow
-      lassieUrl.searchParams.set("depthType", "shallow");
+      lassieUrl.searchParams.set("car-scope", "file");
     } else {
       // for everything else, default to full
-      lassieUrl.searchParams.set("depthType", "full");
+      lassieUrl.searchParams.set("car-scope", "all");
     }
   }
 


### PR DESCRIPTION
# Goals

Update Lassie to support car-scope parameter, a few other things

# For discussion

The conversion of depth parameter to car-scope in lassie.js is cause I think ARC may still be sending only depth=1