### PR TITLE
Fix the watchtower pre-check random wait

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,7 +128,8 @@ COPY container/shim/package*.json ./
 RUN npm ci --production --ignore-scripts
 
 # copy the generated modules and all other files to the container
-COPY container/start.sh ./
+COPY --chmod=0744 container/start.sh ./
+COPY --chmod=0744 container/reload.sh ./
 COPY container/shim ./
 COPY container/nginx /etc/nginx/
 COPY container/logrotate/* /etc/logrotate.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -153,6 +153,9 @@ ARG LASSIE_EXCLUDE_PROVIDERS
 # need nginx to find the openssl libs
 ENV LD_LIBRARY_PATH=/usr/lib/nginx/modules
 
+# for the watchtower container update 
+ENV PRE_UPDATE_WAIT_DIVISOR=3600
+
 ENV NETWORK=$NETWORK
 ENV VERSION=$VERSION
 ENV VERSION_HASH=$VERSION_HASH

--- a/container/reload.sh
+++ b/container/reload.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eux
+
+PRE_UPDATE_WAIT_DIVISOR="${1:-3600}"
+time=$((RANDOM % PRE_UPDATE_WAIT_DIVISOR))
+echo "going to wait $time seconds before updating"
+sleep "$time"

--- a/container/reload.sh
+++ b/container/reload.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eux
 
-PRE_UPDATE_WAIT_DIVISOR="${1:-3600}"
 time=$((RANDOM % PRE_UPDATE_WAIT_DIVISOR))
 echo "going to wait $time seconds before updating"
 sleep "$time"

--- a/container/reload.sh
+++ b/container/reload.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux
+set -eu
 
 time=$((RANDOM % PRE_UPDATE_WAIT_DIVISOR))
 echo "going to wait $time seconds before updating"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.3"
 services:
   saturn-node:
+    init: true
     image: ghcr.io/filecoin-saturn/l1-node:${SATURN_NETWORK:-test}
     container_name: saturn-node
     restart: unless-stopped
@@ -19,8 +20,8 @@ services:
     stop_grace_period: 30m
     labels:
       com.centurylinklabs.watchtower.scope: saturn
-      com.centurylinklabs.watchtower.enable: "true"
-      com.centurylinklabs.watchtower.lifecycle.pre-update: "sleep $$((RANDOM % 3600))"
+      com.centurylinklabs.watchtower.enable: true
+      com.centurylinklabs.watchtower.lifecycle.pre-update: "/usr/src/app/reload.sh"
       com.centurylinklabs.watchtower.lifecycle.pre-update-timeout: 60
     volumes:
       - ${SATURN_HOME:-$HOME}/shared:/usr/src/app/shared

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,10 +32,10 @@ services:
     restart: always
     environment:
       WATCHTOWER_POLL_INTERVAL: 300
-      WATCHTOWER_LABEL_ENABLE: "true"
-      WATCHTOWER_LIFECYCLE_HOOKS: "true"
+      WATCHTOWER_LABEL_ENABLE: true
+      WATCHTOWER_LIFECYCLE_HOOKS: true
       WATCHTOWER_SCOPE: saturn
-      WATCHTOWER_INCLUDE_RESTARTING: "true"
+      WATCHTOWER_INCLUDE_RESTARTING: true
     labels:
       com.centurylinklabs.watchtower.scope: saturn
     volumes:


### PR DESCRIPTION
I noticed this was broken when revisiting this for allowing faster updates on testnet. To fix this: 

- I added running the l1 container with `--init` so signals can be properly caught as we're running multiple processes;
- I also added a new env var to configure the order of magnitude of the random wait;
- I used a script for the random wait as that is the supported way to do this with watchtower.
