### PR TITLE
Scope the auto-update process for docker compose

### DIFF
--- a/docker_compose_update.sh
+++ b/docker_compose_update.sh
@@ -3,8 +3,21 @@
 # keeps docker-compose.yml and itself up to date
 set -eux
 
-branch="${1:-main}"
-repo="https://raw.githubusercontent.com/filecoin-saturn/L1-node/$branch"
+env="$1"
+
+tags="$(curl -fs https://api.github.com/repos/filecoin-saturn/l1-node/tags | grep name | cut -f2 -d ':' | tr -d ',' | tr -d '\"' | tr -d ' ')"
+
+# default to main net
+ref="$(echo "$tags" | grep "^[[:digit:]]" | head -n1)"
+if [ "$env" = "test" ]; then
+    ref="main"
+elif [ "$env" = "canary" ]; then
+    ref="$(echo "$tags" | grep "canary-" | head -n1)"
+elif [ "$env" = "core-L1" ]; then
+    ref="$env"
+fi
+
+repo="https://raw.githubusercontent.com/filecoin-saturn/L1-node/$ref"
 
 curl -fs "$repo/docker_compose_update.sh" -o docker_compose_update.sh
 


### PR DESCRIPTION
The way things are right now, an update to docker-compose.yml will leak to main net, even if there is no release tag.
 I scoped this taking into account the different "environments" we currently support. Note that this is a rather loose notion.

The gist here is to fetch the right tag/branch from Github and use that to scope the docker compose files to the desired environment.

- We default to fetching the latest numeric tag (which is the case for main net);
- For test net, we get whatever's on the main branch;
- For canaries, we get the latest canary tag;
- For core L1s, which have a slightly different config, we get whatever's on their branch (i.e. `core-L1`).

This PR works in tandem with https://github.com/filecoin-saturn/ansible/pull/2.

Also note this whole approach is only compatible with the way we tag right now. If there is any change, this *will break*.