### PR TITLE
update lassie to v0.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,7 +131,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.8.2"
+ARG LASSIE_VERSION="v0.9.0"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \
@@ -166,9 +166,7 @@ ARG ORCHESTRATOR_URL
 
 ARG LASSIE_EVENT_RECORDER_AUTH
 ARG LASSIE_EVENT_RECORDER_URL
-
-# Use random peerId until this is fixed https://github.com/filecoin-project/lassie/issues/191
-ARG LASSIE_EXCLUDE_PROVIDERS="QmcCtpf7ERQWyvDT8RMYWCMjzE74b7HscB3F8gDp5d5yS6"
+ARG LASSIE_EXCLUDE_PROVIDERS
 
 # need nginx to find the openssl libs
 ENV LD_LIBRARY_PATH=/usr/lib/nginx/modules


### PR DESCRIPTION
### Updates
Aggregates event metrics and fixes minor env var and log level bugs
https://github.com/filecoin-project/lassie/releases/tag/v0.9.0

### ! Additional Work Required !
This PR also needs to update the event recorder URL secret to use the new aggregate endpoint. It's the same endpoint, just using `/v2/...` instead of `/v1/...`. I wasn't sure where to go to update that secret.

### Deployment Strategy
We'd like this to be deployed to Canary nodes for a significant amount of time before being pushed up to production so that we have ample time to collect enough metrics to determine that everything seems normal. Ideally the metrics don't change from their current trends. I'll be around until 2023-05-04 04:00 UTC today to check up on things if this get's deployed soon, otherwise I'll be online tomorrow at 2023-05-04 15:00 UTC as well. We're looking to get this out this week before we release HTTP on Lassie.