### PR TITLE
make validateCarBlock throw errors instead of returning bool, so errors get propagated to logging

### DIFF
--- a/container/shim/src/fetchers/lassie.js
+++ b/container/shim/src/fetchers/lassie.js
@@ -256,10 +256,7 @@ async function getRequestedBlockFromCar(streamIn, streamOut, cidObj, filename) {
   let count = 0;
 
   for await (const { cid, bytes } of carBlockIterator) {
-    if (!validateCarBlock(cid, bytes)) {
-      streamOut.status(502);
-      break;
-    }
+    await validateCarBlock(cid, bytes);
 
     const cidV1 = cid.toV1();
     if (count === 0) {


### PR DESCRIPTION
Currently validation errors get printed to stdout, but we should report them in the logs for better visibility

Also, `validateCarBlock` was missing `await` this whole time XD, so it would always return truthy.