### PR TITLE
removes block verification as lassie already does it

### DIFF
--- a/container/shim/src/fetchers/lassie.js
+++ b/container/shim/src/fetchers/lassie.js
@@ -9,7 +9,7 @@ import fetch from "node-fetch";
 
 import { LASSIE_ORIGIN, LASSIE_SP_ELIGIBLE_PORTION, hasNodeToken } from "../config.js";
 import { submitLassieLogs } from "../modules/log_ingestor.js";
-import { streamCAR, validateCarBlock } from "../utils/car.js";
+import { streamCAR } from "../utils/car.js";
 import { proxyResponseHeaders, toUtf8 } from "../utils/http.js";
 import { debug as Debug } from "../utils/logging.js";
 
@@ -256,8 +256,6 @@ async function getRequestedBlockFromCar(streamIn, streamOut, cidObj, filename) {
   let count = 0;
 
   for await (const { cid, bytes } of carBlockIterator) {
-    await validateCarBlock(cid, bytes);
-
     const cidV1 = cid.toV1();
     if (count === 0) {
       if (!cidV1.equals(requestedCidV1)) {

--- a/container/shim/src/utils/car.js
+++ b/container/shim/src/utils/car.js
@@ -41,7 +41,6 @@ export async function streamCAR(streamIn, streamOut) {
     promisify(pipeline)(Readable.from(out), streamOut),
     (async () => {
       for await (const { cid, bytes } of carBlockIterator) {
-        await validateCarBlock(cid, bytes);
         await writer.put({ cid, bytes });
       }
       await writer.close();
@@ -56,8 +55,7 @@ export async function streamCAR(streamIn, streamOut) {
 export async function streamRawFromCAR(streamIn, streamOut) {
   const carBlockIterator = await CarBlockIterator.fromIterable(streamIn);
 
-  for await (const { cid, bytes } of carBlockIterator) {
-    await validateCarBlock(cid, bytes);
+  for await (const { bytes } of carBlockIterator) {
     await write(streamOut, bytes);
   }
   streamOut.end();


### PR DESCRIPTION
Also resolves the issue where blake3 hashed blocks would fail to verify, as L1 didn't support blake3. 