### PR TITLE
Update lassie to v0.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,7 +131,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.9.1"
+ARG LASSIE_VERSION="v0.9.2"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \


### PR DESCRIPTION
Fix for recent crash log with v0.9.1 around concurrent map writes with server-timings library