### PR TITLE
Enable http for Lassie

### DIFF
--- a/container/shim/src/fetchers/lassie.js
+++ b/container/shim/src/fetchers/lassie.js
@@ -114,7 +114,7 @@ export async function respondFromLassie(req, res, { cidObj, format }) {
     res.set("Cache-Control", "public, max-age=29030400, immutable");
 
     // Stream errors will be propagated to the catch block.
-    pipeline(lassieRes.body, metricsStream, () => {});
+    pipeline(lassieRes.body, metricsStream, () => { });
 
     if (isRawFormat) {
       await getRequestedBlockFromCar(metricsStream, res, cidObj, blockFilename);
@@ -208,11 +208,11 @@ function createLassieURL(req, isRawFormat) {
   if (!lassieUrl.searchParams.has("protocols")) {
     const chance = Math.random();
     if (chance < LASSIE_SP_ELIGIBLE_PORTION) {
-      // if we are making an sp eligible request, add bitswap and graphsync
-      lassieUrl.searchParams.set("protocols", "bitswap,graphsync");
+      // if we are making an sp eligible request, add bitswap+http and graphsync
+      lassieUrl.searchParams.set("protocols", "bitswap,graphsync,http");
     } else {
-      // for everything else, just use bitswap
-      lassieUrl.searchParams.set("protocols", "bitswap");
+      // for everything else, just use bitswap+http
+      lassieUrl.searchParams.set("protocols", "bitswap,http");
     }
   }
   return lassieUrl;

--- a/container/start.sh
+++ b/container/start.sh
@@ -66,7 +66,7 @@ export LASSIE_CONCURRENT_SP_RETRIEVALS=1
 export LASSIE_EXPOSE_METRICS=true
 export LASSIE_METRICS_PORT=7776
 export LASSIE_METRICS_ADDRESS=0.0.0.0
-export LASSIE_SUPPORTED_PROTOCOLS="bitswap,graphsync"
+export LASSIE_SUPPORTED_PROTOCOLS="bitswap,graphsync,http"
 export LASSIE_EVENT_RECORDER_URL="https://lassie-event-recorder.dev.cid.contact/v2/retrieval-events"
 
 mkdir -p $LASSIE_TEMP_DIRECTORY


### PR DESCRIPTION
# Goals

We are setting protocols manually in Saturn, so failing to include HTTP in the list meant there was no HTTP fetching.