### PR TITLE
Add a base L1 bifrost docker compose

### DIFF
--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -30,5 +30,5 @@ services:
       STRN_ORCHESTRATOR_URL: https://orchestrator.strn.pl
       CABOOSE_BACKEND_OVERRIDE: saturn-node
     ports:
-      - 8083:8081
-      - 8042:8041
+      - 8081:8081
+      - 8041:8041

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.7"
+services:
+  saturn-node:
+    init: true
+    build:
+      context: ..
+    container_name: saturn-node
+    environment:
+      ORCHESTRATOR_REGISTRATION: false
+      IS_CORE_L1: true
+      FIL_WALLET_ADDRESS: t410f2oekwcmo2pueydmaq53eic2i62crtbeyuzx2gmy
+      NODE_OPERATOR_EMAIL: test@saturn.network
+    ulimits:
+      nofile:
+        soft: 1000000
+        hard: 1000000
+    ports:
+      - 8080:80
+      - 8043:443
+    volumes:
+      - ${SATURN_HOME:-$HOME}/shared:/usr/src/app/shared
+
+  bifrost:
+    build:
+      context: ../../../ipfs/bifrost-gateway
+    container_name: bifrost
+    environment:
+      GRAPH_BACKEND: true
+      GOLOG_LOG_LEVEL: debug
+      STRN_ORCHESTRATOR_URL: https://orchestrator.strn.pl
+      CABOOSE_BACKEND_OVERRIDE: 127.0.0.1:8043
+    ports:
+      - 8083:8081
+      - 8042:8041

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       GRAPH_BACKEND: true
       GOLOG_LOG_LEVEL: debug
       STRN_ORCHESTRATOR_URL: https://orchestrator.strn.pl
-      CABOOSE_BACKEND_OVERRIDE: 127.0.0.1:8043
+      CABOOSE_BACKEND_OVERRIDE: saturn-node
     ports:
       - 8083:8081
       - 8042:8041


### PR DESCRIPTION
Add a basic docker compose file so the bifrost and L1 setup is reproducible locally.

1. Clone the https://github.com/ipfs/bifrost-gateway into `../../../ipfs/bifrost-gateway` (relative to this project)

2. Make sure to generate the L1 certs for localhost with:

```
cd $HOME/shared/ssl
mkcert -key-file node.key -cert-file node.crt localhost
```

3. `cd integration && docker compose up`

4. Fire requests to bifrost (e.g.)

```
curl -v 127.0.0.1:8081/ipfs/$CID -r 0-1048575 # range request
curl -v 127.0.0.1:8081/ipfs/$CID # regular block request
```