### PR TITLE
Update lassie to v0.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.11.1"
+ARG LASSIE_VERSION="v0.12.0"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \


### PR DESCRIPTION
Various bug fixes plus plus some smarter peer selection internally.

Note: please deploy to canary today and let me know so I can give all clear before prod