### PR TITLE
New range request version with correct support for end bound ranges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG NGINX_COMMIT=c38588d8376b
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=6e975bcb015f62e1f303054897783355e2a877dc
 ARG NJS_VERSION=0.7.12
-ARG NGX_CAR_RANGE_VERSION="v0.4.0"
+ARG NGX_CAR_RANGE_VERSION="v0.5.0-rc1"
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -38,5 +38,7 @@ curl -LO -s https://github.com/ipld/go-car/releases/download/v2.8.0/go-car_2.8.0
 # simple range request
 test_range_request "bafybeifpz6onienrgwvb3mw5rg7piq5jh63ystjn7s5wk6ttezy2gy5xwu/Mexico.JPG?entity-bytes=0:1048576"
 
+test_range_request "QmafUYju2Ab4ETi5HJG1cqjmnjs2xw9PUuBKzU7Hi3zvXU/MC_TheSource.mp4?entity-bytes=0:1048576"
+
 # range request with offset
-test_range_request "bafybeifpz6onienrgwvb3mw5rg7piq5jh63ystjn7s5wk6ttezy2gy5xwu/Mexico.JPG?entity-bytes=1048576:2097152"
+# test_range_request "bafybeifpz6onienrgwvb3mw5rg7piq5jh63ystjn7s5wk6ttezy2gy5xwu/Mexico.JPG?entity-bytes=1048576:2097152"


### PR DESCRIPTION
Please note that this version will not work as expected for ranges with a start offset. The goal is to get a first version filtering end bound ranges and seeing if we see an improvement with the most common 1Mb range requests.