### PR TITLE
chore: update lassie to v0.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.15.0"
+ARG LASSIE_VERSION="v0.16.0"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.16.0"
+ARG LASSIE_VERSION="v0.16.1"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/lassie/releases/tag/v0.16.0

Bug fix release, but with a Go version bump too.