### PR TITLE
chore: bump lassie to v0.17.0 w/ entity-bytes support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Download lassie
 ARG TARGETPLATFORM
-ARG LASSIE_VERSION="v0.15.0"
+ARG LASSIE_VERSION="v0.17.0"
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; \
   else ARCHITECTURE=386; fi \

--- a/container/shim/src/fetchers/lassie.js
+++ b/container/shim/src/fetchers/lassie.js
@@ -170,7 +170,7 @@ export async function respondFromLassie(req, res, { cidObj, format }) {
 function createLassieURL(req, isRawFormat) {
   const lassieUrl = new URL(LASSIE_ORIGIN + toUtf8(req.path));
   for (const [key, val] of Object.entries(req.query)) {
-    if (key === "filename") {
+    if (key === "filename" || key === 'entity-bytes') {
       continue;
     }
 


### PR DESCRIPTION
The next step after #474; or you could just jump straight here. This is less of a bugfix release as it has a bunch of internal reorg to make byte ranges work. It's slightly higher risk, although it's been pretty heavily tested and we're confident it's up to the task.

Ref: https://github.com/filecoin-project/lassie/releases/tag/v0.17.0
