### PR TITLE
doc(requirements): require unique /24 block per geolocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ on [Filecoin Slack](https://filecoinproject.slack.com/)! 👋
 
 ### Node hardware requirements
 
-- Linux server with a static public IPv4 address
+- Linux server with a static public IPv4 address in a unique /24 CIDR block
 - Root access / passwordless sudo user ([How to](https://askubuntu.com/questions/147241/execute-sudo-without-password))
 - Ports 80 and 443 free and public to the internet
 - [Docker](https://www.docker.com/) installed ([Instructions here](https://docs.docker.com/engine/install/#server)) with [Docker Compose v2](https://www.docker.com/blog/announcing-compose-v2-general-availability/)


### PR DESCRIPTION
Starting October, each node must have a unique /24 block in its geolocation. This is meant to prevent same operators from running multiple nodes in the same geolocation.