### PR TITLE
fix: import register route to https server

### DIFF
--- a/container/nginx/confs/tls_proxy.conf
+++ b/container/nginx/confs/tls_proxy.conf
@@ -22,6 +22,7 @@ server {
 
     include /usr/src/app/shared/nginx_conf/*.conf;
     include /etc/nginx/conf.d/shared.conf;
+    include /etc/nginx/conf.d/register.conf;
 }
 
 server {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -98,7 +98,7 @@ If this returns `{"error":"Unable to deregister"}` then you may have used the "s
 Note that the _Failed registration: Node ... cannot register with newer version 1044_4292ce7 without deregistering first. Please make sure to set up graceful version upgrades._
 start-up error, which is what typically triggers having to do this, prints the short instead of the long Node ID.
 
-If this returns `{"error":"Invalid nodeId"}` then the syntax is wrong for another reason. 
+If this returns `{"error":"Invalid nodeId"}` then the syntax is wrong for another reason.
 
 Using [`curl`](https://curl.se) this can be done with `curl -X POST https://orchestrator.strn.pl/deregister -H 'Content-Type: application/json' -d '{ "nodeId": "12345678-a3fa-3a10-a123-987e6b543c21" }'`.
 


### PR DESCRIPTION
The `location = /register-check` in `register.conf` will override `location /`  in `shared.conf`, which will allow the `/register-check` request to bypass JWT auth.